### PR TITLE
fix: mobile responsive layout and typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,236 +1,170 @@
-# Portfolio Frontend
+# portfolio-frontend
 
-[![Next.js](https://img.shields.io/badge/Next.js-16.1.6-black)](https://nextjs.org/)
-[![React](https://img.shields.io/badge/React-19.2.3-blue)](https://react.dev/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5-blue)](https://www.typescriptlang.org/)
-[![Tailwind CSS](https://img.shields.io/badge/Tailwind-4-38bdf8)](https://tailwindcss.com/)
-[![Vercel](https://img.shields.io/badge/Vercel-Deploy-black)](https://vercel.com/)
-
-Next.js 16 App Router 기반 포트폴리오 & 기술 블로그 프론트엔드.
-
-**Live:**
-- Production: https://portfolio-front-ten-gamma.vercel.app
-- Preview (dev): https://portfolio-front-develop.vercel.app
-
----
-
-## 아키텍처
-
-```
-브라우저
-  │
-  ▼
-Vercel (Next.js 16)
-  ├─ 서버 컴포넌트 (ISR)   ──fetch──▶  OCI Nginx (HTTPS)
-  │    홈, /projects, /blog               │
-  │    캐시 태그 기반 갱신                  ▼
-  │                                   NestJS (3000)
-  └─ 클라이언트 컴포넌트                    │
-       LikeButton, CommentSection      Supabase PostgreSQL
-       필터, 페이지네이션               Redis (조회수)
-```
-
-### 렌더링 전략
-
-| 페이지 | 방식 | 이유 |
-|--------|------|------|
-| `/` | 서버 컴포넌트 + ISR | 정적 데이터, 빠른 FCP, 뒤로가기 스크롤 복원 |
-| `/projects` | 서버(초기) + 클라이언트(필터/페이지) | 첫 진입 SSR, 이후 인터랙션 |
-| `/blog` | 서버(초기) + 클라이언트(검색/페이지) | 동일 |
-| `/projects/[id]` | 서버 컴포넌트 + ISR | 정적 본문 캐싱 |
-| `/blog/[id]` | 서버 컴포넌트 + ISR | 정적 본문 캐싱 |
-| LikeButton, CommentSection | 클라이언트 컴포넌트 | 실시간 인터랙션 |
-
-### ISR 캐시 갱신 흐름
-
-```
-NestJS (콘텐츠 저장)
-  └─▶ POST /api/revalidate  (x-revalidate-secret 헤더)
-        └─▶ revalidateTag('projects' | 'posts')
-              └─▶ 다음 요청 시 서버에서 NestJS 재호출 → 새 HTML 캐싱
-폴백: revalidate: 3600 (웹훅 실패 시 1시간 후 자동 갱신)
-```
+Next.js 기반 포트폴리오 & 기술 블로그 프론트엔드.  
+Vercel에 배포되며, `portfolio-backend` (NestJS / Oracle Cloud)와 REST API로 통신한다.
 
 ---
 
 ## 기술 스택
 
-| 분류 | 기술 |
+| 영역 | 기술 |
 |------|------|
-| Framework | Next.js 16.1.6 (App Router) |
-| UI | React 19.2.3, Tailwind CSS 4 |
+| Framework | Next.js 16 (App Router) |
 | Language | TypeScript 5 |
-| Auth | Supabase OAuth (Google, GitHub, Kakao) |
-| HTTP | Axios (클라이언트), native fetch (서버 ISR) |
-| Rendering | react-markdown, remark-gfm |
-| Utilities | date-fns, react-icons |
-| Deploy | Vercel (main → Production, develop → Preview) |
+| Styling | Tailwind CSS v4 |
+| Auth | Supabase Auth (`@supabase/ssr`) |
+| HTTP | Axios (모듈 레벨 토큰 관리) |
+| Markdown | react-markdown + remark-gfm |
+| Mail | EmailJS (`@emailjs/browser`) |
+| Deploy | Vercel |
 
 ---
 
 ## 프로젝트 구조
 
 ```
-portfolio-frontend/
-├── app/
-│   ├── page.tsx                    # 홈 (서버 컴포넌트, ISR)
-│   ├── layout.tsx                  # 루트 레이아웃
-│   ├── globals.css
-│   ├── api/
-│   │   └── revalidate/route.ts     # ISR 웹훅 수신 엔드포인트
-│   ├── auth/callback/route.ts      # OAuth 콜백
-│   ├── login/page.tsx
-│   ├── projects/
-│   │   ├── page.tsx                # 목록 (서버 컴포넌트)
-│   │   ├── ProjectsClient.tsx      # 필터/페이지 클라이언트
-│   │   ├── new/page.tsx
-│   │   └── [id]/
-│   │       ├── page.tsx            # 상세 (서버 컴포넌트, ISR)
-│   │       ├── ProjectDetailClient.tsx
-│   │       └── edit/page.tsx
-│   └── blog/
-│       ├── page.tsx                # 목록 (서버 컴포넌트)
-│       ├── BlogClient.tsx          # 검색/페이지 클라이언트
-│       ├── new/page.tsx
-│       └── [id]/
-│           ├── page.tsx            # 상세 (서버 컴포넌트, ISR)
-│           ├── BlogPostClient.tsx
-│           └── edit/page.tsx
-├── components/
-│   ├── Navbar.tsx
-│   ├── AuthButton.tsx
-│   ├── ProjectCard.tsx             # 'use client' (onError 핸들러)
-│   ├── PostCard.tsx
-│   ├── CommentSection.tsx
-│   ├── LikeButton.tsx
-│   ├── TechStackInput.tsx
-│   ├── ThumbnailUploader.tsx
-│   ├── Skills.tsx
-│   ├── Experience.tsx
-│   ├── Education.tsx
-│   └── Contact.tsx
-├── lib/
-│   ├── api/
-│   │   ├── server.ts               # 서버 전용 fetch (ISR 태그 포함)
-│   │   ├── client.ts               # Axios 인스턴스 (JWT 인터셉터)
-│   │   ├── projects.ts             # 클라이언트용 projects API
-│   │   ├── posts.ts                # 클라이언트용 posts API
-│   │   ├── comments.ts
-│   │   └── likes.ts
-│   ├── supabase/
-│   │   ├── client.ts               # 브라우저용
-│   │   └── server.ts               # 서버용
-│   └── utils/
-│       └── devicon.ts
-├── hooks/
-│   ├── useAuth.ts
-│   └── useTheme.ts
-├── public/
-├── .env.local                      # 로컬 환경변수 (git 제외)
-├── .env.example
-├── next.config.ts
-├── vercel.json
-└── tsconfig.json
+app/
+├── page.tsx              # 홈 (SSR — 프로젝트·포스트 병렬 fetch)
+├── blog/                 # 블로그 목록 / 상세 / 작성 / 수정
+├── projects/             # 프로젝트 목록 / 상세 / 작성 / 수정
+├── auth/                 # OAuth 콜백 처리
+├── login/                # 로그인 페이지
+├── debug/                # 개발용 디버그 페이지
+└── globals.css           # 전역 스타일 (Tailwind + .markdown-body)
+
+components/
+├── Navbar.tsx            # 글로벌 Navbar (sticky, 스크롤 blur, 모바일 사이드 패널)
+├── PostCard.tsx          # 블로그 카드 (썸네일 + 메타)
+├── ProjectCard.tsx       # 프로젝트 카드 (썸네일 / devicon 플레이스홀더)
+├── Skills.tsx            # Skills 섹션
+├── Experience.tsx        # 경력 섹션
+├── Education.tsx         # 교육 섹션
+├── Contact.tsx           # EmailJS 문의 폼
+├── AuthButton.tsx        # 로그인/로그아웃 버튼
+├── LikeButton.tsx        # 좋아요 버튼 (클라이언트)
+├── CommentSection.tsx    # 댓글 섹션 (클라이언트)
+└── ...
+
+lib/
+├── api/
+│   ├── client.ts         # Axios 인스턴스 (모듈 레벨 토큰 store)
+│   ├── server.ts         # 서버 컴포넌트용 fetch 함수
+│   ├── posts.ts          # 포스트 API
+│   ├── projects.ts       # 프로젝트 API
+│   ├── comments.ts       # 댓글 API
+│   └── likes.ts          # 좋아요 API
+├── supabase/             # Supabase 클라이언트 (client / server)
+├── types/                # 공통 타입 정의
+└── utils/                # 유틸 함수 (devicon 등)
+
+hooks/
+├── useAuth.ts            # 인증 상태 + isAdmin 판단
+└── useTheme.ts           # 다크모드 토글
 ```
+
+---
+
+## 인증 흐름
+
+```
+브라우저 → Supabase Auth (OAuth: Google / GitHub)
+              ↓ session
+         onAuthStateChange → setAccessToken(session.access_token)
+              ↓ (모듈 레벨 변수)
+         Axios interceptor → Authorization: Bearer <token>
+              ↓
+         portfolio-backend (SupabaseJwtStrategy 검증)
+```
+
+- 매 요청마다 `getSession()` 비동기 호출 없이 동기적으로 토큰 참조 (병목 제거)
+- 401 응답 + Authorization 헤더가 있었던 경우에만 강제 로그아웃 처리
+
+---
+
+## 렌더링 전략
+
+| 페이지 | 전략 | 이유 |
+|--------|------|------|
+| `/` (홈) | SSR | 프로젝트·포스트 병렬 fetch, SEO |
+| `/blog` | SSR + CSR hybrid | 초기 데이터 SSR, 검색·페이지네이션 CSR |
+| `/projects` | SSR + CSR hybrid | 초기 데이터 SSR, 상태 필터 CSR |
+| `/blog/[id]` | SSR (서버컴포넌트 fetch) | 본문 SEO, 좋아요·댓글은 클라이언트 |
+| `/projects/[id]` | SSR | 동일 |
 
 ---
 
 ## 환경변수
 
-### 로컬 (.env.local)
+`.env.local` 기준:
 
 ```env
-# Supabase (OAuth 전용)
-NEXT_PUBLIC_SUPABASE_URL=https://[project-ref].supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-
-# Backend API - 클라이언트(브라우저)용
-NEXT_PUBLIC_API_URL=https://hsm9411.duckdns.org
-
-# Backend API - 서버(Vercel 서버)용, ISR fetch에 사용
-API_URL=https://hsm9411.duckdns.org
-
-# ISR 웹훅 시크릿 (NestJS와 동일한 값)
-REVALIDATE_SECRET=your-secret
-
-# 관리자 이메일 (쉼표 구분)
-NEXT_PUBLIC_ADMIN_EMAILS=your-email@gmail.com
+NEXT_PUBLIC_API_URL=https://<backend-domain>
+NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
+NEXT_PUBLIC_EMAILJS_SERVICE_ID=<service-id>
+NEXT_PUBLIC_EMAILJS_TEMPLATE_ID=<template-id>
+NEXT_PUBLIC_EMAILJS_PUBLIC_KEY=<public-key>
 ```
-
-### Vercel 환경변수 설정
-
-| 변수 | Production | Preview |
-|------|-----------|---------|
-| `NEXT_PUBLIC_API_URL` | `https://hsm9411.duckdns.org` | `https://hsm9411-dev.duckdns.org` |
-| `API_URL` | `https://hsm9411.duckdns.org` | `https://hsm9411-dev.duckdns.org` |
-| `NEXT_PUBLIC_SUPABASE_URL` | (공통) | (공통) |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | (공통) | (공통) |
-| `REVALIDATE_SECRET` | (공통) | (공통) |
-| `NEXT_PUBLIC_ADMIN_EMAILS` | (공통) | (공통) |
-
-`NEXT_PUBLIC_API_URL`과 `API_URL`을 분리하는 이유:
-- `NEXT_PUBLIC_*`는 클라이언트 JS 번들에 포함됨 (브라우저 Axios용)
-- `API_URL`은 서버에서만 사용 (ISR fetch, 클라이언트 번들 비노출)
 
 ---
 
-## 개발 환경 실행
+## 로컬 실행
 
 ```bash
-git clone https://github.com/hsm9411/portfolio-frontend.git
-cd portfolio-frontend
 npm install
-cp .env.example .env.local
-# .env.local 값 채우기
-npm run dev
-```
-
-로컬 개발보다 Vercel Preview 사용 권장 (dev 백엔드 연결 상태 확인 가능).
-
----
-
-## 배포
-
-### Git 흐름
-
-```
-develop 브랜치 작업
-  └─▶ git push origin develop
-        └─▶ Vercel Preview 자동 배포 (dev 백엔드 연결)
-              └─▶ GitHub PR (develop → main)
-                    └─▶ 머지 후 Vercel Production 자동 배포
-```
-
-main 브랜치는 브랜치 보호 설정으로 직접 push 불가, PR 필수.
-
-### 커밋 컨벤션
-
-```
-feat:     새로운 기능
-fix:      버그 수정
-refactor: 리팩토링
-perf:     성능 개선
-style:    UI/CSS 변경
-chore:    빌드, 설정, 의존성
-docs:     문서
+npm run dev       # http://localhost:3000
+npm run build     # 프로덕션 빌드 검증
 ```
 
 ---
 
-## 주요 설계 결정
+## 배포 (Vercel)
 
-**서버/클라이언트 환경변수 분리** — `NEXT_PUBLIC_API_URL`은 브라우저 번들에 포함되어 클라이언트 Axios가 사용. `API_URL`은 서버에서만 실행되는 ISR fetch에서 사용. 동일한 값이어도 용도에 따라 분리.
+Git 연동 자동 배포:
 
-**URL 기반 상태 동기화** — 필터, 페이지, 검색어를 URL 쿼리스트링(`?page=2&status=completed`)으로 관리. 뒤로가기 시 브라우저가 URL을 복원하면 해당 상태로 재fetch되고 스크롤 위치도 복원됨.
+| 브랜치 | 배포 대상 |
+|--------|-----------|
+| `main` | Production (`https://hsm9411.vercel.app` 또는 커스텀 도메인) |
+| `develop` | Preview URL (Vercel 자동 생성) |
 
-**referrer 기반 뒤로가기** — 상세 페이지에서 `document.referrer`로 진입 경로를 감지. 목록에서 왔으면 `router.back()`(스크롤 위치 복원), 직접 진입이면 `router.push('/projects')`로 목록 이동.
+`vercel.json`:
+```json
+{
+  "buildCommand": "npm run build"
+}
+```
 
-**서버/클라이언트 컴포넌트 분리 기준** — 정적 본문(제목, 내용, 기술스택)은 서버 컴포넌트로 ISR 캐싱. 실시간 인터랙션(좋아요, 댓글)은 클라이언트 컴포넌트로 분리하여 별도 fetch.
+환경변수는 Vercel 대시보드 → **Settings > Environment Variables** 에서 관리.  
+`NEXT_PUBLIC_*` 변수는 Production / Preview / Development 환경에 모두 등록해야 빌드가 정상 동작한다.
 
 ---
 
-## Author
+## 브랜치 전략
 
-**hsm9411** | haeha2e@gmail.com | [@hsm9411](https://github.com/hsm9411)
+```
+main        → Production 배포 (Vercel)
+develop     → Preview 배포 (Vercel) — 기능 개발 기본 브랜치
+feature/*   → 기능 단위 개발 → develop PR
+```
 
-Last Updated: 2026-02-26
+---
+
+## 모바일 반응형 기준
+
+Tailwind 브레이크포인트 기준:
+
+| prefix | 범위 | 비고 |
+|--------|------|------|
+| (없음) | 0px~ | 모바일 기본 |
+| `sm:` | 640px~ | 태블릿 세로 |
+| `md:` | 768px~ | 태블릿 가로 / 소형 데스크탑 |
+| `lg:` | 1024px~ | 데스크탑 |
+
+설계 원칙: **모바일 퍼스트** — 기본값을 모바일 기준으로 작성하고 `sm:` / `md:`로 확장.
+
+주요 적용 지점:
+- 섹션 패딩: `py-12 md:py-20`
+- 카드 내부 패딩: `p-4 sm:p-6 md:p-8`
+- 제목: `text-2xl md:text-3xl` / `text-3xl sm:text-4xl md:text-5xl`
+- PostCard 썸네일: `w-[110px] sm:w-[150px] md:w-[170px]`
+- `.markdown-body`: 모바일 `0.9375rem`, `sm:` 이상 `1rem`으로 미디어쿼리 분기

--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -54,19 +54,19 @@ export default function BlogPostClient({ post }: Props) {
       {/* 삭제 확인 모달 */}
       {showDeleteConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 backdrop-blur-sm">
-          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-2xl dark:bg-gray-800">
-            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
-              <svg className="h-6 w-6 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl dark:bg-gray-800 sm:p-6">
+            <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30 sm:h-12 sm:w-12">
+              <svg className="h-5 w-5 text-red-600 dark:text-red-400 sm:h-6 sm:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
               </svg>
             </div>
-            <h3 className="mb-2 text-lg font-bold text-gray-900 dark:text-white">포스트 삭제</h3>
-            <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
+            <h3 className="mb-2 text-base font-bold text-gray-900 dark:text-white sm:text-lg">포스트 삭제</h3>
+            <p className="mb-5 text-xs text-gray-500 dark:text-gray-400 sm:mb-6 sm:text-sm">
               <span className="font-medium text-gray-900 dark:text-white">"{post.title}"</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
-            <div className="flex gap-3">
-              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700">취소</button>
-              <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60">
+            <div className="flex gap-2.5 sm:gap-3">
+              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm">취소</button>
+              <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60 sm:py-2.5 sm:text-sm">
                 {deleting ? '삭제 중...' : '삭제'}
               </button>
             </div>
@@ -76,24 +76,24 @@ export default function BlogPostClient({ post }: Props) {
 
       {/* 상단 네비게이션 */}
       <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
-          <button onClick={handleBack} className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white">
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-4 py-2.5 sm:px-5 sm:py-3">
+          <button onClick={handleBack} className="flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white sm:gap-1.5 sm:px-3 sm:text-sm">
+            <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
             </svg>
             {fromRef.current === 'list' ? '목록으로' : 'Blog'}
           </button>
 
           {isAdmin && (
-            <div className="flex items-center gap-2">
-              <button onClick={() => router.push(`/blog/${post.id}/edit`)} className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700">
-                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <div className="flex items-center gap-1.5 sm:gap-2">
+              <button onClick={() => router.push(`/blog/${post.id}/edit`)} className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 sm:gap-1.5 sm:px-3 sm:text-sm">
+                <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                 </svg>
                 수정
               </button>
-              <button onClick={() => setShowDeleteConfirm(true)} className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20">
-                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <button onClick={() => setShowDeleteConfirm(true)} className="flex items-center gap-1 rounded-lg border border-red-200 bg-white px-2.5 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20 sm:gap-1.5 sm:px-3 sm:text-sm">
+                <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                 </svg>
                 삭제
@@ -105,32 +105,32 @@ export default function BlogPostClient({ post }: Props) {
 
       {/* 헤더 */}
       <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
-        <div className="mx-auto max-w-[1000px] px-5 py-10">
+        <div className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-10">
           {post.tags.length > 0 && (
-            <div className="mb-5 flex flex-wrap gap-2">
+            <div className="mb-4 flex flex-wrap gap-1.5 sm:mb-5 sm:gap-2">
               {post.tags.map((tag) => (
-                <span key={tag} className="rounded-md bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30">#{tag}</span>
+                <span key={tag} className="rounded-md bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30 sm:px-2.5 sm:py-1 sm:text-xs">#{tag}</span>
               ))}
             </div>
           )}
-          <h1 className="mb-3 text-3xl font-bold leading-tight text-gray-900 dark:text-white sm:text-4xl">{post.title}</h1>
-          <p className="mb-6 text-lg leading-relaxed text-gray-600 dark:text-gray-400">{post.summary}</p>
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-gray-500 dark:text-gray-400">
-            <span className="flex items-center gap-1.5">
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+          <h1 className="mb-2.5 text-2xl font-bold leading-tight text-gray-900 dark:text-white sm:mb-3 sm:text-3xl md:text-4xl">{post.title}</h1>
+          <p className="mb-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400 sm:mb-6 sm:text-lg">{post.summary}</p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-gray-500 dark:text-gray-400 sm:gap-x-5 sm:gap-y-2 sm:text-sm">
+            <span className="flex items-center gap-1 sm:gap-1.5">
+              <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
               {post.authorNickname}
             </span>
-            <span className="flex items-center gap-1.5">
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+            <span className="flex items-center gap-1 sm:gap-1.5">
+              <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
               {formatDistanceToNow(new Date(post.createdAt), { addSuffix: true, locale: ko })}
             </span>
-            <span className="flex items-center gap-1.5">
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
+            <span className="flex items-center gap-1 sm:gap-1.5">
+              <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
               {post.viewCount.toLocaleString()}
             </span>
             {post.readingTime && (
-              <span className="flex items-center gap-1.5">
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" /></svg>
+              <span className="flex items-center gap-1 sm:gap-1.5">
+                <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" /></svg>
                 {post.readingTime}분 읽기
               </span>
             )}
@@ -139,19 +139,18 @@ export default function BlogPostClient({ post }: Props) {
       </header>
 
       {/* 본문 */}
-      <main className="mx-auto max-w-[1000px] px-5 py-10">
-        <div className="space-y-8">
-          <section className="rounded-2xl border border-gray-200 bg-white px-6 py-10 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-10 sm:py-12">
+      <main className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-10">
+        <div className="space-y-5 sm:space-y-8">
+          <section className="rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-6 sm:py-10 md:px-10 md:py-12">
             <div className="markdown-body">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{post.content}</ReactMarkdown>
             </div>
           </section>
 
-          {/* 실시간 영역 — 클라이언트에서 별도 fetch */}
-          <div className="rounded-2xl border border-gray-200 bg-white px-6 py-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-6">
             <LikeButton targetType="post" targetId={post.id} initialLikeCount={post.likeCount} />
           </div>
-          <div className="rounded-2xl border border-gray-200 bg-white px-6 py-8 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-8">
+          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-6 sm:py-8 md:px-8">
             <CommentSection targetType="post" targetId={post.id} />
           </div>
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -37,7 +37,7 @@ body {
    @tailwindcss/typography 호환성 이슈 우회
 ───────────────────────────────────────────── */
 .markdown-body {
-  font-size: 1rem;
+  font-size: 0.9375rem; /* 15px — 모바일 기본값 */
   line-height: 1.8;
   color: #374151;
   word-break: break-word;
@@ -70,10 +70,11 @@ body {
   color: #f9fafb;
 }
 
-.markdown-body h1 { font-size: 1.875rem; margin-top: 0; }
-.markdown-body h2 { font-size: 1.5rem;   padding-bottom: 0.4em; border-bottom: 1px solid #e5e7eb; }
-.markdown-body h3 { font-size: 1.25rem; }
-.markdown-body h4 { font-size: 1.125rem; }
+/* 모바일: 제목 크기 한 단계 낮춤 */
+.markdown-body h1 { font-size: 1.5rem;   margin-top: 0; }
+.markdown-body h2 { font-size: 1.25rem;  padding-bottom: 0.4em; border-bottom: 1px solid #e5e7eb; }
+.markdown-body h3 { font-size: 1.125rem; }
+.markdown-body h4 { font-size: 1rem; }
 
 .dark .markdown-body h2 { border-bottom-color: #374151; }
 
@@ -131,11 +132,11 @@ body {
 .markdown-body pre {
   background-color: #1e2433;
   color: #e2e8f0;
-  padding: 1.25em 1.5em;
+  padding: 1em 1.25em;
   border-radius: 0.75rem;
   overflow-x: auto;
   margin: 1.5em 0;
-  font-size: 0.9em;
+  font-size: 0.85em;
   line-height: 1.7;
 }
 
@@ -153,7 +154,7 @@ body {
   background-color: #eff6ff;
   color: #1e40af;
   margin: 1.5em 0;
-  padding: 0.75em 1.25em;
+  padding: 0.75em 1em;
   border-radius: 0 0.5rem 0.5rem 0;
 }
 
@@ -170,7 +171,7 @@ body {
 /* 리스트 */
 .markdown-body ul,
 .markdown-body ol {
-  padding-left: 1.75em;
+  padding-left: 1.5em;
   margin: 1em 0;
 }
 
@@ -209,12 +210,17 @@ body {
   border-top-color: #374151;
 }
 
-/* 표 (GFM) */
+/* 표 (GFM) — 모바일: 가로 스크롤 래퍼 */
+.markdown-body .table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .markdown-body table {
   width: 100%;
   border-collapse: collapse;
   margin: 1.5em 0;
-  font-size: 0.9em;
+  font-size: 0.85em;
   overflow: hidden;
   border-radius: 0.5rem;
   border: 1px solid #e5e7eb;
@@ -229,7 +235,7 @@ body {
   font-weight: 600;
   color: #374151;
   text-align: left;
-  padding: 0.65em 1em;
+  padding: 0.5em 0.75em;
   border-bottom: 2px solid #e5e7eb;
 }
 
@@ -240,7 +246,7 @@ body {
 }
 
 .markdown-body td {
-  padding: 0.6em 1em;
+  padding: 0.5em 0.75em;
   border-bottom: 1px solid #f3f4f6;
   color: #374151;
 }
@@ -274,4 +280,32 @@ body {
 /* 첫 번째 자식 요소 상단 마진 제거 */
 .markdown-body > *:first-child {
   margin-top: 0;
+}
+
+/* ─────────────────────────────────────────────
+   sm(640px) 이상: 원래 데스크탑 크기 복원
+───────────────────────────────────────────── */
+@media (min-width: 640px) {
+  .markdown-body {
+    font-size: 1rem;
+  }
+
+  .markdown-body h1 { font-size: 1.875rem; }
+  .markdown-body h2 { font-size: 1.5rem; }
+  .markdown-body h3 { font-size: 1.25rem; }
+  .markdown-body h4 { font-size: 1.125rem; }
+
+  .markdown-body pre {
+    padding: 1.25em 1.5em;
+    font-size: 0.9em;
+  }
+
+  .markdown-body th,
+  .markdown-body td {
+    padding: 0.6em 1em;
+  }
+
+  .markdown-body table {
+    font-size: 0.9em;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,6 @@ import Education from '@/components/Education'
 import Contact from '@/components/Contact'
 
 export default async function Home() {
-  // 서버에서 병렬 fetch → 뒤로가기 시 레이아웃이 즉시 완성된 상태로 렌더링
   const [projectsData, postsData] = await Promise.all([
     fetchProjects({ page: 1, limit: 6, sortBy: 'created_at', order: 'DESC' })
       .then((r) => r.items as Project[])
@@ -25,19 +24,19 @@ export default async function Home() {
 
       {/* ── 히어로 ── */}
       <section className="flex min-h-[calc(100vh-72px)] items-center justify-center border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
-        <div className="mx-auto flex w-full max-w-[900px] flex-col items-center gap-12 px-5 pb-[5vh] pt-8 md:flex-row md:items-center md:justify-between md:gap-16">
+        <div className="mx-auto flex w-full max-w-[900px] flex-col items-center gap-8 px-5 pb-8 pt-8 md:flex-row md:items-center md:justify-between md:gap-16 md:pb-[5vh]">
           <div className="text-center md:text-left">
-            <h1 className="mb-6 text-4xl font-black leading-tight tracking-tight text-gray-900 dark:text-white sm:text-5xl">
+            <h1 className="mb-4 text-3xl font-black leading-tight tracking-tight text-gray-900 dark:text-white sm:text-4xl md:text-5xl">
               안녕하세요,<br />
               개발자 하성민입니다.
             </h1>
-            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+            <p className="text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:text-base">
               최근에는 <strong className="font-semibold text-gray-800 dark:text-gray-200">웹개발</strong>과{' '}
-              <strong className="font-semibold text-gray-800 dark:text-gray-200">시스템 개발</strong>에 필요한 기능을 구현하기 위해<br />
+              <strong className="font-semibold text-gray-800 dark:text-gray-200">시스템 개발</strong>에 필요한 기능을 구현하기 위해<br className="hidden sm:block" />
               다양한 <strong className="font-semibold text-gray-800 dark:text-gray-200">CS 개념</strong>과 기술들에 관심을 가지고 학습하고 있습니다.
             </p>
-            <p className="mt-4 text-base leading-relaxed text-gray-500 dark:text-gray-400">
-              또한, 효율적인 <strong className="font-semibold text-gray-800 dark:text-gray-200">협업</strong>을 위해 필요한 툴과 기술,<br />
+            <p className="mt-3 text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:mt-4 sm:text-base">
+              또한, 효율적인 <strong className="font-semibold text-gray-800 dark:text-gray-200">협업</strong>을 위해 필요한 툴과 기술,<br className="hidden sm:block" />
               그리고 <strong className="font-semibold text-gray-800 dark:text-gray-200">개발 프로세스 체계</strong>를 경험하며 성장하고 있습니다.
             </p>
           </div>
@@ -45,7 +44,7 @@ export default async function Home() {
             <img
               src="/profile.png"
               alt="Profile"
-              className="w-[240px] h-auto border border-gray-200 object-cover shadow-[15px_15px_0px_rgba(0,0,0,0.1)] dark:border-gray-700 dark:shadow-[15px_15px_0px_rgba(255,255,255,0.05)]"
+              className="w-[180px] h-auto border border-gray-200 object-cover shadow-[12px_12px_0px_rgba(0,0,0,0.1)] dark:border-gray-700 dark:shadow-[12px_12px_0px_rgba(255,255,255,0.05)] sm:w-[210px] md:w-[240px] md:shadow-[15px_15px_0px_rgba(0,0,0,0.1)]"
             />
           </div>
         </div>
@@ -54,33 +53,33 @@ export default async function Home() {
       <Skills />
 
       {/* ── 콘텐츠 ── */}
-      <main className="mx-auto max-w-[1000px] px-5 py-12">
-        <div className="space-y-16">
+      <main className="mx-auto max-w-[1000px] px-4 py-8 sm:px-5 sm:py-12">
+        <div className="space-y-12 sm:space-y-16">
 
           {/* Projects */}
           <section>
-            <div className="mb-6 flex items-center justify-between">
+            <div className="mb-5 flex items-center justify-between sm:mb-6">
               <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Recent Projects</h2>
-                <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">최근 작업한 프로젝트</p>
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white sm:text-xl">Recent Projects</h2>
+                <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 sm:text-sm">최근 작업한 프로젝트</p>
               </div>
               <Link
                 href="/projects"
-                className="flex items-center gap-1 text-sm font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                className="flex items-center gap-1 text-xs font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 sm:text-sm"
               >
                 전체보기
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                 </svg>
               </Link>
             </div>
 
             {projectsData.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-gray-200 py-14 text-center dark:border-gray-700">
+              <div className="rounded-2xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700 sm:py-14">
                 <p className="text-sm text-gray-400">아직 프로젝트가 없습니다.</p>
               </div>
             ) : (
-              <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid gap-4 sm:grid-cols-2 sm:gap-5 lg:grid-cols-3">
                 {projectsData.map((project) => (
                   <Link key={project.id} href={`/projects/${project.id}`} className="block">
                     <ProjectCard project={project} />
@@ -92,28 +91,28 @@ export default async function Home() {
 
           {/* Blog */}
           <section>
-            <div className="mb-6 flex items-center justify-between">
+            <div className="mb-5 flex items-center justify-between sm:mb-6">
               <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Recent Posts</h2>
-                <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">최근 작성한 블로그 포스트</p>
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white sm:text-xl">Recent Posts</h2>
+                <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 sm:text-sm">최근 작성한 블로그 포스트</p>
               </div>
               <Link
                 href="/blog"
-                className="flex items-center gap-1 text-sm font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                className="flex items-center gap-1 text-xs font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 sm:text-sm"
               >
                 전체보기
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                 </svg>
               </Link>
             </div>
 
             {postsData.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-gray-200 py-14 text-center dark:border-gray-700">
+              <div className="rounded-2xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700 sm:py-14">
                 <p className="text-sm text-gray-400">아직 포스트가 없습니다.</p>
               </div>
             ) : (
-              <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-3 sm:gap-4">
                 {postsData.map((post) => (
                   <Link key={post.id} href={`/blog/${post.id}`} className="block">
                     <PostCard post={post} />
@@ -131,8 +130,8 @@ export default async function Home() {
       <Contact />
 
       {/* Footer */}
-      <footer className="mt-16 border-t border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
-        <div className="mx-auto max-w-[1000px] px-5 py-8">
+      <footer className="mt-12 border-t border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:mt-16">
+        <div className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-8">
           <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-between">
             <p className="text-sm font-semibold text-gray-500 dark:text-gray-400">hsm9411</p>
             <p className="text-xs text-gray-400 dark:text-gray-600">

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -33,53 +33,52 @@ export default function Contact() {
 
   return (
     <section className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
-      <div className="mx-auto max-w-[1000px] px-5 py-20">
-        <h2 className="mb-4 text-center text-3xl font-black tracking-tight text-gray-900 dark:text-white">
+      <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
+        <h2 className="mb-3 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-4 md:text-3xl">
           Contact
         </h2>
-        <p className="mb-12 text-center text-base text-gray-500 dark:text-gray-400">
+        <p className="mb-8 text-center text-sm text-gray-500 dark:text-gray-400 md:mb-12 md:text-base">
           궁금한 점이 있으시거나 협업 제안은 언제든 환영합니다.
         </p>
 
-        <form ref={form} onSubmit={sendEmail} className="mx-auto flex max-w-[600px] flex-col gap-5">
+        <form ref={form} onSubmit={sendEmail} className="mx-auto flex max-w-[600px] flex-col gap-4 sm:gap-5">
           <input
             type="text"
             name="user_name"
             placeholder="이름 (Name)"
             required
-            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-[15px] text-base text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400"
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400 sm:py-[15px] sm:text-base"
           />
           <input
             type="email"
             name="user_email"
             placeholder="이메일 (Email)"
             required
-            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-[15px] text-base text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400"
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400 sm:py-[15px] sm:text-base"
           />
           <textarea
             name="message"
             placeholder="내용을 입력해주세요 (Message)"
             required
             rows={6}
-            className="w-full resize-y rounded-lg border border-gray-200 bg-white px-4 py-[15px] text-base text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400"
+            className="w-full resize-y rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400 sm:py-[15px] sm:text-base"
           />
           <button
             type="submit"
             disabled={status === 'sending'}
-            className="w-full rounded-lg bg-gray-900 py-[15px] text-[1.05rem] font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-50 dark:bg-gray-100 dark:text-gray-900"
+            className="w-full rounded-lg bg-gray-900 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-50 dark:bg-gray-100 dark:text-gray-900 sm:py-[15px] sm:text-[1.05rem]"
           >
             {status === 'sending' ? '전송 중...' : '메일 보내기'}
           </button>
         </form>
 
-        {/* 상태 메시지 */}
         {status === 'success' && (
-          <p className="mt-6 text-center text-sm font-medium text-green-600 dark:text-green-400">
+          <p className="mt-5 text-center text-sm font-medium text-green-600 dark:text-green-400 sm:mt-6">
             ✅ 성공적으로 메일이 발송되었습니다!
           </p>
         )}
         {status === 'error' && (
-          <p className="mt-6 text-center text-sm font-medium text-red-500 dark:text-red-400">
+          <p className="mt-5 text-center text-sm font-medium text-red-500 dark:text-red-400 sm:mt-6">
             ❌ 전송 실패. 환경변수 또는 네트워크를 확인해주세요.
           </p>
         )}

--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -11,22 +11,22 @@ const educations = [
 export default function Education() {
   return (
     <section className="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50">
-      <div className="mx-auto max-w-[1000px] px-5 py-20">
-        <h2 className="mb-12 text-center text-3xl font-black tracking-tight text-gray-900 dark:text-white">
+      <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
+        <h2 className="mb-8 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-12 md:text-3xl">
           Education
         </h2>
-        <div className="mx-auto max-w-[800px] space-y-5">
+        <div className="mx-auto max-w-[800px] space-y-4 sm:space-y-5">
           {educations.map((edu) => (
             <div
               key={edu.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-8 transition-colors duration-200 hover:border-gray-400 hover:border-l-blue-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-blue-400"
+              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-blue-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-blue-400 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                <span className="text-xl font-extrabold text-gray-900 dark:text-white">{edu.course}</span>
-                <span className="text-sm font-medium text-gray-400 dark:text-gray-500">{edu.period}</span>
+                <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{edu.course}</span>
+                <span className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:text-sm">{edu.period}</span>
               </div>
-              <strong className="mb-3 block text-base font-semibold text-blue-600 dark:text-blue-400">{edu.org}</strong>
-              <p className="text-[1.05rem] leading-relaxed text-gray-500 dark:text-gray-400">{edu.desc}</p>
+              <strong className="mb-2 block text-sm font-semibold text-blue-600 dark:text-blue-400 sm:mb-3 sm:text-base">{edu.org}</strong>
+              <p className="text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:text-[1.05rem]">{edu.desc}</p>
             </div>
           ))}
         </div>

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -11,22 +11,22 @@ const experiences = [
 export default function Experience() {
   return (
     <section className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
-      <div className="mx-auto max-w-[1000px] px-5 py-20">
-        <h2 className="mb-12 text-center text-3xl font-black tracking-tight text-gray-900 dark:text-white">
+      <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
+        <h2 className="mb-8 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-12 md:text-3xl">
           Experience
         </h2>
-        <div className="mx-auto max-w-[800px] space-y-5">
+        <div className="mx-auto max-w-[800px] space-y-4 sm:space-y-5">
           {experiences.map((exp) => (
             <div
               key={exp.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-8 transition-colors duration-200 hover:border-gray-400 hover:border-l-blue-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-blue-400"
+              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-blue-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-blue-400 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                <span className="text-xl font-extrabold text-gray-900 dark:text-white">{exp.role}</span>
-                <span className="text-sm font-medium text-gray-400 dark:text-gray-500">{exp.period}</span>
+                <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{exp.role}</span>
+                <span className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:text-sm">{exp.period}</span>
               </div>
-              <strong className="mb-3 block text-base font-semibold text-blue-600 dark:text-blue-400">{exp.org}</strong>
-              <p className="text-[1.05rem] leading-relaxed text-gray-500 dark:text-gray-400">{exp.desc}</p>
+              <strong className="mb-2 block text-sm font-semibold text-blue-600 dark:text-blue-400 sm:mb-3 sm:text-base">{exp.org}</strong>
+              <p className="text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:text-[1.05rem]">{exp.desc}</p>
             </div>
           ))}
         </div>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -15,73 +15,61 @@ const categoryConfig: Record<string, { label: string; className: string }> = {
 
 const calcReadTime = (content: string) => Math.max(1, Math.ceil(content.length / 500))
 
-/*
-  레이아웃 계산 (카드 전체 h-[170px])
-  ├─ 카테고리 뱃지행   h-[22px]
-  ├─ gap                      8px
-  ├─ 제목 2줄  16px×1.4×2  = 46px  (h-[46px])
-  ├─ gap                      6px
-  ├─ 요약 2줄  14px×1.5×2  = 42px  (h-[42px])
-  ├─ mt-auto
-  └─ 메타행                  20px
-     + padding top/bottom 40px (py-5 = 20×2)
-  합계 ≈ 22+8+46+6+42+20+40 = 184px → 패딩 줄여 py-4(16×2=32) → 170px
-*/
 export default function PostCard({ post }: PostCardProps) {
   const category = categoryConfig[post.category] ?? { label: post.category, className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400' }
   const readTime = post.readingTime ?? calcReadTime(post.content)
 
   return (
-    <article className="group flex h-[170px] overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
+    <article className="group flex overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
 
       {/* 텍스트 영역 */}
-      <div className="flex min-w-0 flex-1 flex-col py-4 pl-5 pr-4">
+      <div className="flex min-w-0 flex-1 flex-col py-3.5 pl-4 pr-3 sm:py-4 sm:pl-5 sm:pr-4">
 
-        {/* 카테고리 + 태그 — h-[22px] */}
-        <div className="flex h-[22px] items-center gap-1.5">
-          <span className={`shrink-0 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${category.className}`}>
+        {/* 카테고리 + 태그 */}
+        <div className="flex items-center gap-1.5 overflow-hidden">
+          <span className={`shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ring-1 ring-inset sm:px-2.5 sm:text-xs ${category.className}`}>
             {category.label}
           </span>
           {post.tags.slice(0, 2).map((tag) => (
-            <span key={tag} className="shrink-0 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+            <span key={tag} className="shrink-0 rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400 sm:px-2 sm:text-xs">
               #{tag}
             </span>
           ))}
           {post.tags.length > 2 && (
-            <span className="text-xs text-gray-400 dark:text-gray-500">+{post.tags.length - 2}</span>
+            <span className="text-[10px] text-gray-400 dark:text-gray-500 sm:text-xs">+{post.tags.length - 2}</span>
           )}
         </div>
 
-        {/* 제목 — 2줄, 16px×1.4×2 = 44.8px → h-[46px] */}
-        <h2 className="mt-2 line-clamp-2 h-[46px] overflow-hidden text-base font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400">
+        {/* 제목 */}
+        <h2 className="mt-1.5 line-clamp-2 text-sm font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400 sm:mt-2 sm:text-base">
           {post.title}
         </h2>
 
-        {/* 요약 — 2줄, 14px×1.5×2 = 42px → h-[42px] */}
-        <p className="mt-1.5 line-clamp-2 h-[42px] overflow-hidden text-sm leading-[1.5] text-gray-500 dark:text-gray-400">
+        {/* 요약 */}
+        <p className="mt-1 line-clamp-2 text-xs leading-[1.5] text-gray-500 dark:text-gray-400 sm:mt-1.5 sm:text-sm">
           {post.summary}
         </p>
 
-        {/* 메타 — mt-auto로 하단 고정 */}
-        <div className="mt-auto flex items-center gap-x-4 text-xs text-gray-400 dark:text-gray-500">
+        {/* 메타 */}
+        <div className="mt-auto flex items-center gap-x-3 pt-2 text-[10px] text-gray-400 dark:text-gray-500 sm:gap-x-4 sm:text-xs">
           <span className="flex items-center gap-1">
-            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
             </svg>
             {post.viewCount.toLocaleString()}
           </span>
           <span className="flex items-center gap-1">
-            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
             </svg>
             {post.likeCount.toLocaleString()}
           </span>
           <span className="flex items-center gap-1">
-            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            {readTime}분 읽기
+            {readTime}분
           </span>
           <span className="ml-auto">
             {formatDistanceToNow(new Date(post.createdAt), { addSuffix: true, locale: ko })}
@@ -89,9 +77,9 @@ export default function PostCard({ post }: PostCardProps) {
         </div>
       </div>
 
-      {/* 썸네일 — 카드 전체 높이에 맞춤, 없으면 영역 없음 */}
+      {/* 썸네일 — 모바일에서 너비 축소, 없으면 영역 없음 */}
       {post.thumbnailUrl && (
-        <div className="w-[170px] shrink-0">
+        <div className="w-[110px] shrink-0 sm:w-[150px] md:w-[170px]">
           <img
             src={post.thumbnailUrl}
             alt={post.title}

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -42,25 +42,25 @@ const skillCategories = [
 export default function Skills() {
   return (
     <section className="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50">
-      <div className="mx-auto max-w-[1000px] px-5 py-20">
-        <h2 className="mb-12 text-center text-3xl font-black tracking-tight text-gray-900 dark:text-white">
+      <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
+        <h2 className="mb-8 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-12 md:text-3xl">
           Skills & Capabilities
         </h2>
-        <div className="grid gap-6 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2 sm:gap-6">
           {skillCategories.map(({ icon: Icon, title, items }) => (
             <div
               key={title}
-              className="rounded-xl border border-gray-200 bg-white p-6 transition-all duration-200 hover:-translate-y-1 hover:border-blue-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/60 dark:hover:border-blue-500"
+              className="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:-translate-y-1 hover:border-blue-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/60 dark:hover:border-blue-500 sm:p-6"
             >
               {/* 카드 헤더 */}
-              <div className="mb-4 flex items-center gap-3 border-b border-gray-100 pb-3 dark:border-gray-700">
-                <Icon className="text-xl text-blue-600 dark:text-blue-400" />
-                <h3 className="font-bold text-gray-900 dark:text-white">{title}</h3>
+              <div className="mb-3 flex items-center gap-3 border-b border-gray-100 pb-3 dark:border-gray-700 sm:mb-4">
+                <Icon className="text-lg text-blue-600 dark:text-blue-400 sm:text-xl" />
+                <h3 className="text-sm font-bold text-gray-900 dark:text-white sm:text-base">{title}</h3>
               </div>
               {/* 아이템 리스트 */}
-              <ul className="space-y-2">
+              <ul className="space-y-1.5 sm:space-y-2">
                 {items.map((item) => (
-                  <li key={item} className="text-sm leading-relaxed text-gray-500 dark:text-gray-400">
+                  <li key={item} className="text-xs leading-relaxed text-gray-500 dark:text-gray-400 sm:text-sm">
                     {item}
                   </li>
                 ))}


### PR DESCRIPTION
- 섹션 패딩 py-20 → py-12 md:py-20 (Skills, Experience, Education, Contact)
- 카드 패딩 p-8/p-6 → p-4 sm:p-6 md:p-8 (Experience, Education)
- Hero h1 text-3xl sm:text-4xl md:text-5xl 점진적 스케일
- PostCard 썸네일 w-[110px] sm:w-[150px] md:w-[170px] 모바일 축소
- PostCard 고정 높이 제거, 텍스트 크기 xs/sm 브레이크포인트 분기
- BlogPostClient header/main px, py 모바일 값 축소
- globals.css markdown-body 모바일 기본 0.9375rem, sm: 이상 1rem
- globals.css 모바일 h1~h4 크기 한 단계 낮춤, sm: 이상 원래 크기 복원
- README.md 프로젝트 전체 문서화