### PR TITLE
fix(projects, blog): 필터 초기화 시 목록 미노출 버그 수정

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { getPosts, type Post } from '@/lib/api/posts'
 import PostCard from '@/components/PostCard'
@@ -34,6 +34,14 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   const [searchInput, setSearchInput] = useState(searchFromUrl)
   const { isAdmin } = useAuth()
 
+  /**
+   * 최초 마운트 여부 추적
+   * ProjectsClient와 동일한 버그 — 검색어 지운 뒤 초기화(전체 목록) 시
+   * `pageFromUrl === 1 && searchFromUrl === ''` 조건에 걸려 fetch를 스킵하는 문제.
+   * isInitialRender ref로 최초 마운트만 스킵, 이후는 항상 fetch.
+   */
+  const isInitialRender = useRef(true)
+
   const loadPosts = useCallback(async (page: number, search: string) => {
     try {
       setLoading(true)
@@ -50,7 +58,17 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   }, [])
 
   useEffect(() => {
-    if (pageFromUrl === 1 && searchFromUrl === '') return
+    if (isInitialRender.current) {
+      isInitialRender.current = false
+      if (pageFromUrl === 1 && searchFromUrl === '') {
+        // SSR 데이터로 충분한 초기 상태 — fetch 스킵
+        return
+      }
+      // URL에 검색어/페이지가 있는 상태로 최초 진입 → fetch 필요
+    }
+
+    // 마운트 이후 URL 변경 시 항상 fetch
+    // (검색 초기화 포함)
     loadPosts(pageFromUrl, searchFromUrl)
   }, [pageFromUrl, searchFromUrl, loadPosts])
 

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { getProjects, type Project } from '@/lib/api/projects'
 import ProjectCard from '@/components/ProjectCard'
@@ -26,7 +26,6 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  // URL 쿼리스트링에서 상태 읽기 → 뒤로가기 시 브라우저가 URL 복원 → 상태도 복원됨
   const pageFromUrl   = Number(searchParams.get('page'))   || 1
   const statusFromUrl = searchParams.get('status') || 'all'
 
@@ -41,7 +40,22 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   )
   const { isAdmin } = useAuth()
 
-  // URL 변경 시 데이터 fetch
+  /**
+   * 최초 마운트 여부 추적
+   *
+   * 문제 원인:
+   *   useEffect 내부에서 `pageFromUrl === 1 && statusFromUrl === 'all'` 조건으로
+   *   fetch를 스킵했는데, 이 조건이 두 가지 상황을 구분하지 못한다.
+   *
+   *   1) 최초 진입 → SSR 데이터 그대로 써야 하므로 fetch 스킵 (의도된 동작)
+   *   2) 다른 필터 → 전체 탭으로 복귀 → 반드시 fetch 해야 하는데 스킵됨 (버그)
+   *
+   *   URL 조건만으로는 두 경우를 구분할 수 없으므로,
+   *   `isInitialRender` ref로 마운트 첫 실행 여부를 추적한다.
+   *   초기 진입이면 스킵, 이후 URL이 변경되어 effect가 재실행되면 항상 fetch.
+   */
+  const isInitialRender = useRef(true)
+
   const loadProjects = useCallback(async (page: number, status: string) => {
     try {
       setLoading(true)
@@ -58,12 +72,22 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   }, [])
 
   useEffect(() => {
-    // 초기 상태(page=1, status=all)는 SSR 데이터 그대로 사용
-    if (pageFromUrl === 1 && statusFromUrl === 'all') return
+    // 최초 마운트: SSR initialData 그대로 사용
+    // 단, URL에 이미 필터/페이지가 있으면 (직접 URL 입력, 뒤로가기 복원 등) fetch 필요
+    if (isInitialRender.current) {
+      isInitialRender.current = false
+      if (pageFromUrl === 1 && statusFromUrl === 'all') {
+        // SSR 데이터로 충분한 초기 상태 — fetch 스킵
+        return
+      }
+      // URL에 필터/페이지가 있는 상태로 최초 진입 → fetch 필요
+    }
+
+    // 마운트 이후 URL 변경 시 항상 fetch
+    // (전체 탭 복귀 포함)
     loadProjects(pageFromUrl, statusFromUrl)
   }, [pageFromUrl, statusFromUrl, loadProjects])
 
-  // 필터/페이지 변경 → URL 업데이트 (뒤로가기에 기록됨)
   const updateUrl = (page: number, status: string) => {
     const params = new URLSearchParams()
     if (page > 1)         params.set('page', String(page))


### PR DESCRIPTION
## 관련 이슈
refs #6

## 변경 내용
`useEffect` 스킵 조건이 최초 SSR 진입과 필터 복귀를 구분하지 못해
전체 탭 클릭 시 fetch가 실행되지 않는 버그 수정.

`isInitialRender` ref를 도입해 마운트 첫 실행만 SSR 데이터로 처리하고,
이후 URL 변경은 항상 fetch 실행하도록 변경.

**변경 파일**
- `app/projects/ProjectsClient.tsx`
- `app/blog/BlogClient.tsx`

## 테스트 체크리스트
- [ ] `/projects` 진입 → 전체 목록 정상 노출
- [ ] 완료 → 진행중 → 전체 순으로 필터 전환, 각 결과 정상
- [ ] 페이지 2 → 전체 탭 클릭 → page=1 전체 목록 정상
- [ ] 뒤로가기 시 이전 필터 상태 복원 정상
- [ ] `/blog` 검색 → 초기화 → 전체 목록 정상 노출

## 머지 대상
`feature/fix-projects-filter-reset` → `develop`