### PR TITLE
chore(release): develop → main 배포 (모바일 반응형 + 필터 버그 수정)

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { getPosts, type Post } from '@/lib/api/posts'
 import PostCard from '@/components/PostCard'
@@ -34,6 +34,14 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   const [searchInput, setSearchInput] = useState(searchFromUrl)
   const { isAdmin } = useAuth()
 
+  /**
+   * 최초 마운트 여부 추적
+   * ProjectsClient와 동일한 버그 — 검색어 지운 뒤 초기화(전체 목록) 시
+   * `pageFromUrl === 1 && searchFromUrl === ''` 조건에 걸려 fetch를 스킵하는 문제.
+   * isInitialRender ref로 최초 마운트만 스킵, 이후는 항상 fetch.
+   */
+  const isInitialRender = useRef(true)
+
   const loadPosts = useCallback(async (page: number, search: string) => {
     try {
       setLoading(true)
@@ -50,7 +58,17 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   }, [])
 
   useEffect(() => {
-    if (pageFromUrl === 1 && searchFromUrl === '') return
+    if (isInitialRender.current) {
+      isInitialRender.current = false
+      if (pageFromUrl === 1 && searchFromUrl === '') {
+        // SSR 데이터로 충분한 초기 상태 — fetch 스킵
+        return
+      }
+      // URL에 검색어/페이지가 있는 상태로 최초 진입 → fetch 필요
+    }
+
+    // 마운트 이후 URL 변경 시 항상 fetch
+    // (검색 초기화 포함)
     loadPosts(pageFromUrl, searchFromUrl)
   }, [pageFromUrl, searchFromUrl, loadPosts])
 

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { getProjects, type Project } from '@/lib/api/projects'
 import ProjectCard from '@/components/ProjectCard'
@@ -26,7 +26,6 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  // URL 쿼리스트링에서 상태 읽기 → 뒤로가기 시 브라우저가 URL 복원 → 상태도 복원됨
   const pageFromUrl   = Number(searchParams.get('page'))   || 1
   const statusFromUrl = searchParams.get('status') || 'all'
 
@@ -41,7 +40,22 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   )
   const { isAdmin } = useAuth()
 
-  // URL 변경 시 데이터 fetch
+  /**
+   * 최초 마운트 여부 추적
+   *
+   * 문제 원인:
+   *   useEffect 내부에서 `pageFromUrl === 1 && statusFromUrl === 'all'` 조건으로
+   *   fetch를 스킵했는데, 이 조건이 두 가지 상황을 구분하지 못한다.
+   *
+   *   1) 최초 진입 → SSR 데이터 그대로 써야 하므로 fetch 스킵 (의도된 동작)
+   *   2) 다른 필터 → 전체 탭으로 복귀 → 반드시 fetch 해야 하는데 스킵됨 (버그)
+   *
+   *   URL 조건만으로는 두 경우를 구분할 수 없으므로,
+   *   `isInitialRender` ref로 마운트 첫 실행 여부를 추적한다.
+   *   초기 진입이면 스킵, 이후 URL이 변경되어 effect가 재실행되면 항상 fetch.
+   */
+  const isInitialRender = useRef(true)
+
   const loadProjects = useCallback(async (page: number, status: string) => {
     try {
       setLoading(true)
@@ -58,12 +72,22 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   }, [])
 
   useEffect(() => {
-    // 초기 상태(page=1, status=all)는 SSR 데이터 그대로 사용
-    if (pageFromUrl === 1 && statusFromUrl === 'all') return
+    // 최초 마운트: SSR initialData 그대로 사용
+    // 단, URL에 이미 필터/페이지가 있으면 (직접 URL 입력, 뒤로가기 복원 등) fetch 필요
+    if (isInitialRender.current) {
+      isInitialRender.current = false
+      if (pageFromUrl === 1 && statusFromUrl === 'all') {
+        // SSR 데이터로 충분한 초기 상태 — fetch 스킵
+        return
+      }
+      // URL에 필터/페이지가 있는 상태로 최초 진입 → fetch 필요
+    }
+
+    // 마운트 이후 URL 변경 시 항상 fetch
+    // (전체 탭 복귀 포함)
     loadProjects(pageFromUrl, statusFromUrl)
   }, [pageFromUrl, statusFromUrl, loadProjects])
 
-  // 필터/페이지 변경 → URL 업데이트 (뒤로가기에 기록됨)
   const updateUrl = (page: number, status: string) => {
     const params = new URLSearchParams()
     if (page > 1)         params.set('page', String(page))


### PR DESCRIPTION
## 배포 개요
develop 브랜치에 누적된 변경사항을 main(Production)에 반영.

## 포함된 작업

### 1. 모바일 반응형 개선
- 섹션 패딩 `py-20` → `py-12 md:py-20` (Skills, Experience, Education, Contact)
- 카드 패딩 `p-8/p-6` → `p-4 sm:p-6 md:p-8` (Experience, Education)
- Hero h1 `text-3xl sm:text-4xl md:text-5xl` 점진적 스케일 적용
- PostCard 썸네일 `w-[110px] sm:w-[150px] md:w-[170px]` 모바일 축소
- PostCard 고정 높이 제거, 텍스트 크기 브레이크포인트 분기
- BlogPostClient header/main px, py 모바일 값 축소
- `.markdown-body` 모바일 기본 `0.9375rem`, `sm:` 이상 `1rem`
- 모바일 h1~h4 크기 한 단계 낮춤, `sm:` 이상 원래 크기 복원

### 2. 필터 초기화 시 목록 미노출 버그 수정
- refs #6
- `ProjectsClient`: 전체 탭 복귀 시 fetch 미실행 버그 수정
- `BlogClient`: 검색 초기화 시 동일 버그 동시 수정
- `isInitialRender` ref 도입으로 최초 마운트만 SSR 데이터 유지,
  이후 URL 변경은 항상 fetch 실행

### 3. README 추가
- 프로젝트 구조, 인증 흐름, 렌더링 전략, 배포 방식, 반응형 기준 문서화

## 변경 파일
- `app/page.tsx`
- `app/globals.css`
- `app/blog/BlogClient.tsx`
- `app/blog/[id]/BlogPostClient.tsx`
- `app/projects/ProjectsClient.tsx`
- `components/Skills.tsx`
- `components/Experience.tsx`
- `components/Education.tsx`
- `components/Contact.tsx`
- `components/PostCard.tsx`
- `README.md`

## 테스트 체크리스트
- [ ] 모바일(360px) 홈 Hero 제목 wrapping 자연스러운지
- [ ] Skills / Experience / Education 카드 패딩 여유 확인
- [ ] PostCard 썸네일 있을 때 텍스트 영역 충분한지
- [ ] 블로그 본문 마크다운 폰트 크기 적절한지
- [ ] Projects 필터 전환 → 전체 복귀 시 목록 정상 노출
- [ ] Blog 검색 → 초기화 시 전체 목록 정상 노출
- [ ] 뒤로가기 필터 상태 복원 정상

## Closes
Closes #6