### PR TITLE
[Fix] 로그인 페이지 /register 링크 제거

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -254,16 +254,8 @@ function LoginForm() {
         </form>
 
         {/* Footer */}
-        <div className="mt-6 text-center text-sm">
-          <span className="text-gray-600 dark:text-gray-400">
-            계정이 없으신가요?{' '}
-          </span>
-          <Link
-            href="/register"
-            className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400"
-          >
-            회원가입
-          </Link>
+        <div className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
+          소셜 계정으로 로그인하면 자동으로 회원가입됩니다.
         </div>
 
         <div className="mt-4 text-center">


### PR DESCRIPTION
## 관련 이슈
closes #14

## 변경 유형
- [x] Bug fix

## 변경 내용
OAuth 전용 인증 구조에 맞게 존재하지 않는 `/register` 페이지 링크를 제거하고, 소셜 로그인으로 자동 가입됨을 안내하는 문구로 대체.

## 구현 세부사항
- "계정이 없으신가요? 회원가입" 링크 블록 제거
- "소셜 계정으로 로그인하면 자동으로 회원가입됩니다." 안내 문구로 교체
- TypeScript 빌드 에러 해소 (`Cannot find module '../../../app/register/page.js'`)

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 확인
- [x] 콘솔 에러 없음

## 머지 대상
`fix/14-remove-register-link` → `develop`