### PR TITLE
[Feature] SEO 메타데이터 및 Open Graph 태그 적용

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -1,9 +1,36 @@
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { fetchPostById } from '@/lib/api/server'
 import BlogPostClient from './BlogPostClient'
 
 interface Props {
   params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  try {
+    const post = await fetchPostById(id)
+    return {
+      title: post.title,
+      description: post.summary,
+      openGraph: {
+        title: post.title,
+        description: post.summary,
+        url: `/blog/${id}`,
+        type: 'article',
+        publishedTime: post.publishedAt ?? post.createdAt,
+        tags: post.tags,
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: post.title,
+        description: post.summary,
+      },
+    }
+  } catch {
+    return { title: '포스트를 찾을 수 없습니다' }
+  }
 }
 
 export default async function BlogPostPage({ params }: Props) {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,17 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import { fetchPosts } from '@/lib/api/server'
 import BlogClient from './BlogClient'
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: '개발 경험과 기술적 인사이트를 담은 블로그 포스트 모음입니다.',
+  openGraph: {
+    title: 'Blog | hsm',
+    description: '개발 경험과 기술적 인사이트를 담은 블로그 포스트 모음입니다.',
+    url: '/blog',
+  },
+}
 
 export default async function BlogPage() {
   let initialData = { items: [], total: 0, page: 1, pageSize: 10, totalPages: 1 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,8 +15,25 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Portfolio",
-  description: "개발자 포트폴리오 & 기술 블로그",
+  metadataBase: new URL('https://portfolio-front-ten-gamma.vercel.app'),
+  title: {
+    default: 'hsm | Portfolio',
+    template: '%s | hsm',
+  },
+  description: '개발자 포트폴리오 & 기술 블로그. 프로젝트 경험과 기술적 인사이트를 공유합니다.',
+  openGraph: {
+    type: 'website',
+    locale: 'ko_KR',
+    siteName: 'hsm Portfolio',
+    title: 'hsm | Portfolio',
+    description: '개발자 포트폴리오 & 기술 블로그. 프로젝트 경험과 기술적 인사이트를 공유합니다.',
+    url: 'https://portfolio-front-ten-gamma.vercel.app',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'hsm | Portfolio',
+    description: '개발자 포트폴리오 & 기술 블로그. 프로젝트 경험과 기술적 인사이트를 공유합니다.',
+  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,17 @@
+import type { Metadata } from 'next'
 import { fetchProjects, fetchPosts } from '@/lib/api/server'
 import { type Project } from '@/lib/api/projects'
 import { type Post } from '@/lib/api/posts'
+
+export const metadata: Metadata = {
+  title: { absolute: 'hsm | Portfolio' },
+  description: '개발자 포트폴리오 & 기술 블로그. 프로젝트 경험과 기술적 인사이트를 공유합니다.',
+  openGraph: {
+    title: 'hsm | Portfolio',
+    description: '개발자 포트폴리오 & 기술 블로그. 프로젝트 경험과 기술적 인사이트를 공유합니다.',
+    url: '/',
+  },
+}
 import ProjectCard from '@/components/ProjectCard'
 import PostCard from '@/components/PostCard'
 import Link from 'next/link'

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,9 +1,33 @@
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { fetchProjectById } from '@/lib/api/server'
 import ProjectDetailClient from './ProjectDetailClient'
 
 interface Props {
   params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  try {
+    const project = await fetchProjectById(id)
+    return {
+      title: project.title,
+      description: project.summary,
+      openGraph: {
+        title: project.title,
+        description: project.summary,
+        url: `/projects/${id}`,
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: project.title,
+        description: project.summary,
+      },
+    }
+  } catch {
+    return { title: '프로젝트를 찾을 수 없습니다' }
+  }
 }
 
 export default async function ProjectDetailPage({ params }: Props) {

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,6 +1,17 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import { fetchProjects } from '@/lib/api/server'
 import ProjectsClient from './ProjectsClient'
+
+export const metadata: Metadata = {
+  title: 'Projects',
+  description: '개인 및 팀 프로젝트 모음입니다. 사용 기술과 구현 과정을 확인해보세요.',
+  openGraph: {
+    title: 'Projects | hsm',
+    description: '개인 및 팀 프로젝트 모음입니다. 사용 기술과 구현 과정을 확인해보세요.',
+    url: '/projects',
+  },
+}
 
 export default async function ProjectsPage() {
   let initialData = { items: [], total: 0, page: 1, pageSize: 9, totalPages: 1 }


### PR DESCRIPTION
## 관련 이슈
closes #16

## 변경 유형
- [x] New feature

## 변경 내용
각 페이지에 title, description, Open Graph, Twitter Card 태그를 추가하여 검색 노출 및 링크 공유 미리보기를 개선한다.

## 구현 세부사항

**`layout.tsx`** — 전역 기본값 설정
- `metadataBase` 설정으로 상대경로 OG URL 자동 처리
- `title.template: '%s | hsm'` — 하위 페이지 title에 자동으로 `| hsm` 접미사 적용
- 기본 OG, Twitter Card 태그 설정

**정적 메타데이터** (목록 페이지)
- `app/page.tsx`: `title: { absolute: 'hsm | Portfolio' }` — 홈은 template 미적용
- `app/blog/page.tsx`: `title: 'Blog'` → "Blog | hsm"
- `app/projects/page.tsx`: `title: 'Projects'` → "Projects | hsm"

**동적 메타데이터** (상세 페이지)
- `app/blog/[id]/page.tsx`: `generateMetadata`로 포스트 title/summary/tags/publishedAt 활용
- `app/projects/[id]/page.tsx`: `generateMetadata`로 프로젝트 title/summary 활용
- fetch 실패 시 fallback title 반환

## 체크리스트
- [x] 로컬 빌드 성공 확인
- [x] 콘솔 에러 없음

## 머지 대상
`feature/16-seo-metadata` → `develop`