### PR TITLE
[Feature] Error Boundary 및 Not Found 페이지 추가

### DIFF
--- a/app/blog/error.tsx
+++ b/app/blog/error.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+
+interface Props {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function BlogError({ error, reset }: Props) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+      <div className="w-full max-w-md text-center">
+        <div className="mb-6 flex justify-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+            <svg className="h-8 w-8 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+          </div>
+        </div>
+        <h2 className="mb-2 text-xl font-bold text-gray-900 dark:text-white">
+          블로그를 불러오지 못했습니다
+        </h2>
+        <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
+          일시적인 오류가 발생했습니다. 다시 시도해 주세요.
+        </p>
+        <div className="flex justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+          >
+            다시 시도
+          </button>
+          <Link
+            href="/"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            홈으로
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect } from 'react'
+
+interface Props {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function GlobalError({ error, reset }: Props) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+      <div className="w-full max-w-md text-center">
+        <div className="mb-6 flex justify-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+            <svg className="h-8 w-8 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+          </div>
+        </div>
+        <h2 className="mb-2 text-xl font-bold text-gray-900 dark:text-white">
+          문제가 발생했습니다
+        </h2>
+        <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
+          일시적인 오류가 발생했습니다. 다시 시도해 주세요.
+        </p>
+        <div className="flex justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+          >
+            다시 시도
+          </button>
+          <a
+            href="/"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            홈으로
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+      <div className="w-full max-w-md text-center">
+        <p className="mb-2 text-7xl font-extrabold text-blue-600 dark:text-blue-400">404</p>
+        <h2 className="mb-3 text-xl font-bold text-gray-900 dark:text-white">
+          페이지를 찾을 수 없습니다
+        </h2>
+        <p className="mb-8 text-sm text-gray-500 dark:text-gray-400">
+          요청하신 페이지가 존재하지 않거나 삭제되었습니다.
+        </p>
+        <Link
+          href="/"
+          className="inline-block rounded-xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+        >
+          홈으로 돌아가기
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/projects/error.tsx
+++ b/app/projects/error.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+
+interface Props {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function ProjectsError({ error, reset }: Props) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+      <div className="w-full max-w-md text-center">
+        <div className="mb-6 flex justify-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+            <svg className="h-8 w-8 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+          </div>
+        </div>
+        <h2 className="mb-2 text-xl font-bold text-gray-900 dark:text-white">
+          프로젝트를 불러오지 못했습니다
+        </h2>
+        <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
+          일시적인 오류가 발생했습니다. 다시 시도해 주세요.
+        </p>
+        <div className="flex justify-center gap-3">
+          <button
+            onClick={reset}
+            className="rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+          >
+            다시 시도
+          </button>
+          <Link
+            href="/"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            홈으로
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 관련 이슈
closes #18

## 변경 유형
- [x] New feature

## 변경 내용
런타임 에러 발생 시 빈 화면 크래시를 방지하는 Error Boundary와 404 페이지를 추가한다.

## 구현 세부사항

Next.js App Router의 `error.tsx` 파일 컨벤션 활용 — `'use client'` 컴포넌트로 해당 라우트 세그먼트를 자동으로 에러 경계로 감쌈.

| 파일 | 역할 |
|---|---|
| `app/error.tsx` | 전역 에러 경계 — 모든 페이지 fallback |
| `app/blog/error.tsx` | 블로그 영역 에러 경계 |
| `app/projects/error.tsx` | 프로젝트 영역 에러 경계 |
| `app/not-found.tsx` | 존재하지 않는 경로 접근 시 404 UI |

에러 발생 시 "다시 시도(`reset`)" / "홈으로" 버튼을 제공하여 복구 경로를 안내.

## 체크리스트
- [x] 로컬 빌드 성공 확인
- [x] 다크모드 확인
- [x] 콘솔 에러 없음

## 머지 대상
`feature/18-error-boundary` → `develop`