### PR TITLE
[Fix] document.referrer 기반 네비게이션 감지를 searchParams 방식으로 교체

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -166,7 +166,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
           <>
             <div className="flex flex-col gap-4">
               {posts.map((post) => (
-                <Link key={post.id} href={`/blog/${post.id}`} className="block">
+                <Link key={post.id} href={`/blog/${post.id}?from=list`} className="block">
                   <PostCard post={post} />
                 </Link>
               ))}

--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { type Post } from '@/lib/api/posts'
 import { useAuth } from '@/hooks/useAuth'
@@ -15,25 +15,17 @@ import api from '@/lib/api/client'
 
 interface Props {
   post: Post
+  from?: string
 }
 
-export default function BlogPostClient({ post }: Props) {
+export default function BlogPostClient({ post, from }: Props) {
   const router = useRouter()
   const { isAdmin } = useAuth()
   const [deleting, setDeleting] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
-  const fromRef = useRef<'list' | 'home'>('home')
-  useEffect(() => {
-    const prev = document.referrer
-    fromRef.current =
-      prev.includes('/blog') && !prev.includes(`/blog/${post.id}`)
-        ? 'list'
-        : 'home'
-  }, [post.id])
-
   const handleBack = () => {
-    fromRef.current === 'list' ? router.back() : router.push('/blog')
+    from === 'list' ? router.back() : router.push('/blog')
   }
 
   const handleDelete = async () => {
@@ -82,7 +74,7 @@ export default function BlogPostClient({ post }: Props) {
             <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
             </svg>
-            {fromRef.current === 'list' ? '목록으로' : 'Blog'}
+            {from === 'list' ? '목록으로' : 'Blog'}
           </button>
 
           {isAdmin && (

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -5,6 +5,7 @@ import BlogPostClient from './BlogPostClient'
 
 interface Props {
   params: Promise<{ id: string }>
+  searchParams: Promise<{ from?: string }>
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -33,8 +34,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 }
 
-export default async function BlogPostPage({ params }: Props) {
+export default async function BlogPostPage({ params, searchParams }: Props) {
   const { id } = await params
+  const { from } = await searchParams
 
   let post
   try {
@@ -43,5 +45,5 @@ export default async function BlogPostPage({ params }: Props) {
     notFound()
   }
 
-  return <BlogPostClient post={post} />
+  return <BlogPostClient post={post} from={from} />
 }

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -154,7 +154,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
           <>
             <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
               {projects.map((project) => (
-                <Link key={project.id} href={`/projects/${project.id}`} className="block">
+                <Link key={project.id} href={`/projects/${project.id}?from=list`} className="block">
                   <ProjectCard project={project} />
                 </Link>
               ))}

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { type Project } from '@/lib/api/projects'
 import { useAuth } from '@/hooks/useAuth'
@@ -15,6 +15,7 @@ import api from '@/lib/api/client'
 
 interface Props {
   project: Project
+  from?: string
 }
 
 const statusConfig = {
@@ -23,23 +24,14 @@ const statusConfig = {
   archived:    { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
-export default function ProjectDetailClient({ project }: Props) {
+export default function ProjectDetailClient({ project, from }: Props) {
   const router = useRouter()
   const { isAdmin } = useAuth()
   const [deleting, setDeleting] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
-  const fromRef = useRef<'list' | 'home'>('home')
-  useEffect(() => {
-    const prev = document.referrer
-    fromRef.current =
-      prev.includes('/projects') && !prev.includes(`/projects/${project.id}`)
-        ? 'list'
-        : 'home'
-  }, [project.id])
-
   const handleBack = () => {
-    fromRef.current === 'list' ? router.back() : router.push('/projects')
+    from === 'list' ? router.back() : router.push('/projects')
   }
 
   const handleDelete = async () => {
@@ -90,7 +82,7 @@ export default function ProjectDetailClient({ project }: Props) {
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
             </svg>
-            {fromRef.current === 'list' ? '목록으로' : 'Projects'}
+            {from === 'list' ? '목록으로' : 'Projects'}
           </button>
 
           {isAdmin && (

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import ProjectDetailClient from './ProjectDetailClient'
 
 interface Props {
   params: Promise<{ id: string }>
+  searchParams: Promise<{ from?: string }>
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -30,8 +31,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 }
 
-export default async function ProjectDetailPage({ params }: Props) {
+export default async function ProjectDetailPage({ params, searchParams }: Props) {
   const { id } = await params
+  const { from } = await searchParams
 
   let project
   try {
@@ -40,5 +42,5 @@ export default async function ProjectDetailPage({ params }: Props) {
     notFound()
   }
 
-  return <ProjectDetailClient project={project} />
+  return <ProjectDetailClient project={project} from={from} />
 }


### PR DESCRIPTION
## 관련 이슈
closes #20

## 변경 유형
- [x] Bug fix

## 변경 내용
`document.referrer`에 의존하던 뒤로가기 버튼 동작 감지를 `?from=list` 쿼리 파라미터 방식으로 교체하여 신뢰성을 높인다.

## 구현 세부사항

**기존 방식의 문제**
- `document.referrer`는 브라우저 프라이버시 정책, 직접 URL 입력, 새 탭 열기 등에서 빈 값 반환
- 오작동 시 "목록으로" 버튼 미표시

**변경 후 흐름**
```
목록(BlogClient/ProjectsClient)
  → href="/blog/{id}?from=list"  ← ?from=list 추가
  → page.tsx에서 searchParams 수신
  → Client 컴포넌트에 from prop으로 전달
  → from === 'list' ? router.back() : router.push('/blog')
```

**제거된 코드**
- `useRef<'list' | 'home'>`, `useEffect`, `document.referrer` 로직 완전 제거
- `import { useRef, useEffect }` 미사용 import 제거

## 체크리스트
- [x] 로컬 빌드 성공 확인
- [x] 콘솔 에러 없음

## 머지 대상
`fix/20-navigation-from-param` → `develop`