### PR TITLE
[Fix] 하드코딩된 백엔드 IP 주소 제거

### DIFF
--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -7,7 +7,7 @@ import type { ApiError } from '@/lib/types/api'
 
 const API_TIMEOUT = 25000 // 25초
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://158.180.75.205'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL
 
 // ============================================
 // Session Token Store


### PR DESCRIPTION
## 관련 이슈
closes #22

## 변경 유형
- [x] Bug fix

## 변경 내용
`lib/api/client.ts`에 하드코딩된 백엔드 IP(`158.180.75.205`) fallback을 제거하고 `NEXT_PUBLIC_API_URL` 환경변수만 사용하도록 수정.

## 구현 세부사항
```ts
// Before
const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://158.180.75.205'

// After
const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL
```

DuckDNS(`hsm9411.duckdns.org`) 정상 작동 확인 후 진행.
로컬 `.env.local` 및 Vercel 환경변수에 `NEXT_PUBLIC_API_URL` 설정 필요.

> ⚠️ **머지 전 체크**: Vercel 대시보드 → Settings → Environment Variables에 `NEXT_PUBLIC_API_URL=https://hsm9411.duckdns.org` 등록 확인

## 체크리스트
- [x] 로컬 빌드 성공 확인
- [x] DuckDNS 응답 확인

## 머지 대상
`fix/22-remove-hardcoded-ip` → `develop`