### PR TITLE
[Fix] 로그인 페이지 오픈 리다이렉트 취약점 수정

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -16,8 +16,10 @@ function LoginForm() {
   const searchParams = useSearchParams()
   const supabase = createClient()
 
-  // 리다이렉트 URL
-  const redirectUrl = searchParams.get('redirect') || '/'
+  // 리다이렉트 URL — 외부 도메인으로의 오픈 리다이렉트 방지
+  // '/'로 시작하지 않거나 '//'로 시작하는 값(프로토콜 상대 URL)은 홈으로 fallback
+  const raw = searchParams.get('redirect') || '/'
+  const redirectUrl = raw.startsWith('/') && !raw.startsWith('//') ? raw : '/'
 
   // 로그인 상태 확인
   useEffect(() => {


### PR DESCRIPTION
## 관련 이슈
closes #24

## 변경 유형
- [x] Bug fix

## 변경 내용
`?redirect=` 파라미터 검증 없이 로그인 후 임의의 URL로 리다이렉트되는 취약점을 수정한다.

## 취약점 설명

**공격 시나리오:**
```
/login?redirect=https://evil.com
→ 정상 로그인 완료
→ evil.com(피싱 페이지)으로 리다이렉트
```
도메인이 정상 사이트처럼 보이기 때문에 피해자가 속기 쉬운 피싱 공격에 활용 가능.

**수정 내용:**
```ts
// Before
const redirectUrl = searchParams.get('redirect') || '/'

// After
const raw = searchParams.get('redirect') || '/'
const redirectUrl = raw.startsWith('/') && !raw.startsWith('//') ? raw : '/'
```

차단 케이스:
- `https://evil.com` → `/` (절대 URL)
- `//evil.com` → `/` (프로토콜 상대 URL)
- `javascript:alert(1)` → `/` (스킴 공격)

허용 케이스:
- `/blog`, `/projects/123` 등 내부 경로는 정상 동작 유지

## 체크리스트
- [x] 로컬 빌드 성공 확인
- [x] 내부 경로 리다이렉트 정상 동작 확인
- [x] 외부 URL 차단 확인

## 머지 대상
`fix/24-open-redirect` → `develop`