### PR TITLE
feat: img 태그를 Next.js Image 컴포넌트로 교체

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ next-env.d.ts
 
 # Claude Code
 .claude
+CLAUDE.md
+CLAUDE.local.md

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -11,6 +11,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
+import Image from 'next/image'
 import api from '@/lib/api/client'
 
 interface Props {
@@ -139,8 +140,14 @@ export default function ProjectDetailClient({ project, from }: Props) {
       <main className="mx-auto max-w-[1000px] px-5 py-10">
         <div className="space-y-8">
           {project.thumbnailUrl && (
-            <div className="overflow-hidden rounded-2xl shadow-md">
-              <img src={project.thumbnailUrl} alt={project.title} className="w-full object-cover" />
+            <div className="relative aspect-video overflow-hidden rounded-2xl shadow-md">
+              <Image
+                src={project.thumbnailUrl}
+                alt={project.title}
+                fill
+                sizes="(max-width: 1000px) 100vw, 1000px"
+                className="object-cover"
+              />
             </div>
           )}
 

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import type { Post } from '@/lib/api/posts'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
@@ -79,11 +80,13 @@ export default function PostCard({ post }: PostCardProps) {
 
       {/* 썸네일 — 모바일에서 너비 축소, 없으면 영역 없음 */}
       {post.thumbnailUrl && (
-        <div className="w-[110px] shrink-0 sm:w-[150px] md:w-[170px]">
-          <img
+        <div className="relative w-[110px] shrink-0 self-stretch sm:w-[150px] md:w-[170px]">
+          <Image
             src={post.thumbnailUrl}
             alt={post.title}
-            className="h-full w-full object-cover"
+            fill
+            sizes="170px"
+            className="object-cover"
           />
         </div>
       )}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import type { Project } from '@/lib/api/projects'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
@@ -24,12 +25,14 @@ export default function ProjectCard({ project }: ProjectCardProps) {
     <div className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
 
       {/* 썸네일 */}
-      <div className="aspect-video w-full overflow-hidden">
+      <div className="relative aspect-video w-full overflow-hidden">
         {project.thumbnailUrl ? (
-          <img
+          <Image
             src={project.thumbnailUrl}
             alt={project.title}
-            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
           />
         ) : (
           /* 플레이스홀더: 그라디언트 배경 + devicon 아이콘 */
@@ -42,10 +45,12 @@ export default function ProjectCard({ project }: ProjectCardProps) {
                     className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/20 p-2 backdrop-blur-sm"
                     style={{ opacity: 1 - i * 0.2 }}
                   >
-                    <img
+                    <Image
                       src={url}
                       alt=""
-                      className="h-full w-full object-contain brightness-0 invert"
+                      width={32}
+                      height={32}
+                      className="object-contain brightness-0 invert"
                       onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
                     />
                   </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,18 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "k.kakaocdn.net", // Kakao OAuth 프로필
       },
+      {
+        protocol: "https",
+        hostname: "cdn.jsdelivr.net", // devicon 기술 스택 아이콘
+      },
+      {
+        protocol: "https",
+        hostname: "**", // 백엔드 업로드 썸네일 (동적 호스트)
+      },
+      {
+        protocol: "http",
+        hostname: "**", // 백엔드 업로드 썸네일 (개발 환경)
+      },
     ],
   },
 


### PR DESCRIPTION
## 관련 이슈
closes #26

## 변경 유형
- [x] Feature (기능 개선)
- [x] Performance (성능 최적화)

## 변경 내용
- `PostCard`, `ProjectCard`, `ProjectDetailClient`의 `<img>` 태그를 Next.js `<Image>` 컴포넌트로 교체
- `fill` + `sizes` 속성 적용으로 lazy loading, WebP 자동 변환, 적절한 해상도 요청 처리
- `next.config.ts` remotePatterns에 `cdn.jsdelivr.net`(devicon 아이콘), 백엔드 동적 호스트(`**`) 추가
- `.gitignore`에 `CLAUDE.md`, `CLAUDE.local.md` 추가

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 프로덕션 빌드 성공 (`npm run build`)
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거