### PR TITLE
refactor: isInitialRender ref 워크어라운드 제거 및 코드 정리

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -22,25 +22,17 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   const pageFromUrl   = Number(searchParams.get('page'))   || 1
   const searchFromUrl = searchParams.get('search') || ''
 
-  const [posts, setPosts]             = useState<Post[]>(
-    pageFromUrl === 1 && searchFromUrl === '' ? initialData.items : []
-  )
-  const [totalPages, setTotalPages]   = useState(
-    pageFromUrl === 1 && searchFromUrl === '' ? initialData.totalPages : 1
-  )
-  const [loading, setLoading]         = useState(
-    !(pageFromUrl === 1 && searchFromUrl === '')
-  )
+  // SSR initialData는 항상 page=1, 검색 없음 기준으로 받아옴
+  const isDefaultUrl = pageFromUrl === 1 && searchFromUrl === ''
+
+  const [posts, setPosts]             = useState<Post[]>(isDefaultUrl ? initialData.items : [])
+  const [totalPages, setTotalPages]   = useState(isDefaultUrl ? initialData.totalPages : 1)
+  const [loading, setLoading]         = useState(!isDefaultUrl)
   const [searchInput, setSearchInput] = useState(searchFromUrl)
   const { isAdmin } = useAuth()
 
-  /**
-   * 최초 마운트 여부 추적
-   * ProjectsClient와 동일한 버그 — 검색어 지운 뒤 초기화(전체 목록) 시
-   * `pageFromUrl === 1 && searchFromUrl === ''` 조건에 걸려 fetch를 스킵하는 문제.
-   * isInitialRender ref로 최초 마운트만 스킵, 이후는 항상 fetch.
-   */
-  const isInitialRender = useRef(true)
+  // 최초 마운트 시 SSR 데이터를 그대로 쓰는 경우 fetch 스킵
+  const hasMounted = useRef(false)
 
   const loadPosts = useCallback(async (page: number, search: string) => {
     try {
@@ -58,19 +50,12 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   }, [])
 
   useEffect(() => {
-    if (isInitialRender.current) {
-      isInitialRender.current = false
-      if (pageFromUrl === 1 && searchFromUrl === '') {
-        // SSR 데이터로 충분한 초기 상태 — fetch 스킵
-        return
-      }
-      // URL에 검색어/페이지가 있는 상태로 최초 진입 → fetch 필요
+    if (!hasMounted.current) {
+      hasMounted.current = true
+      if (isDefaultUrl) return  // 최초 진입, SSR 데이터로 충분
     }
-
-    // 마운트 이후 URL 변경 시 항상 fetch
-    // (검색 초기화 포함)
     loadPosts(pageFromUrl, searchFromUrl)
-  }, [pageFromUrl, searchFromUrl, loadPosts])
+  }, [pageFromUrl, searchFromUrl, isDefaultUrl, loadPosts])
 
   const updateUrl = (page: number, search: string) => {
     const params = new URLSearchParams()

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -29,32 +29,16 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   const pageFromUrl   = Number(searchParams.get('page'))   || 1
   const statusFromUrl = searchParams.get('status') || 'all'
 
-  const [projects, setProjects]     = useState<Project[]>(
-    pageFromUrl === 1 && statusFromUrl === 'all' ? initialData.items : []
-  )
-  const [totalPages, setTotalPages] = useState(
-    pageFromUrl === 1 && statusFromUrl === 'all' ? initialData.totalPages : 1
-  )
-  const [loading, setLoading]       = useState(
-    !(pageFromUrl === 1 && statusFromUrl === 'all')
-  )
+  // SSR initialData는 항상 page=1, status=all 기준으로 받아옴
+  const isDefaultUrl = pageFromUrl === 1 && statusFromUrl === 'all'
+
+  const [projects, setProjects]     = useState<Project[]>(isDefaultUrl ? initialData.items : [])
+  const [totalPages, setTotalPages] = useState(isDefaultUrl ? initialData.totalPages : 1)
+  const [loading, setLoading]       = useState(!isDefaultUrl)
   const { isAdmin } = useAuth()
 
-  /**
-   * 최초 마운트 여부 추적
-   *
-   * 문제 원인:
-   *   useEffect 내부에서 `pageFromUrl === 1 && statusFromUrl === 'all'` 조건으로
-   *   fetch를 스킵했는데, 이 조건이 두 가지 상황을 구분하지 못한다.
-   *
-   *   1) 최초 진입 → SSR 데이터 그대로 써야 하므로 fetch 스킵 (의도된 동작)
-   *   2) 다른 필터 → 전체 탭으로 복귀 → 반드시 fetch 해야 하는데 스킵됨 (버그)
-   *
-   *   URL 조건만으로는 두 경우를 구분할 수 없으므로,
-   *   `isInitialRender` ref로 마운트 첫 실행 여부를 추적한다.
-   *   초기 진입이면 스킵, 이후 URL이 변경되어 effect가 재실행되면 항상 fetch.
-   */
-  const isInitialRender = useRef(true)
+  // 최초 마운트 시 SSR 데이터를 그대로 쓰는 경우 fetch 스킵
+  const hasMounted = useRef(false)
 
   const loadProjects = useCallback(async (page: number, status: string) => {
     try {
@@ -72,21 +56,12 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   }, [])
 
   useEffect(() => {
-    // 최초 마운트: SSR initialData 그대로 사용
-    // 단, URL에 이미 필터/페이지가 있으면 (직접 URL 입력, 뒤로가기 복원 등) fetch 필요
-    if (isInitialRender.current) {
-      isInitialRender.current = false
-      if (pageFromUrl === 1 && statusFromUrl === 'all') {
-        // SSR 데이터로 충분한 초기 상태 — fetch 스킵
-        return
-      }
-      // URL에 필터/페이지가 있는 상태로 최초 진입 → fetch 필요
+    if (!hasMounted.current) {
+      hasMounted.current = true
+      if (isDefaultUrl) return  // 최초 진입, SSR 데이터로 충분
     }
-
-    // 마운트 이후 URL 변경 시 항상 fetch
-    // (전체 탭 복귀 포함)
     loadProjects(pageFromUrl, statusFromUrl)
-  }, [pageFromUrl, statusFromUrl, loadProjects])
+  }, [pageFromUrl, statusFromUrl, isDefaultUrl, loadProjects])
 
   const updateUrl = (page: number, status: string) => {
     const params = new URLSearchParams()


### PR DESCRIPTION
## 관련 이슈
closes #27

## 변경 유형
- [x] Refactor (코드 개선)

## 변경 내용
- 중복된 조건식 `pageFromUrl === 1 && ...`을 `isDefaultUrl` 변수로 추출
- `isInitialRender` → `hasMounted` 로 이름 변경 (의도 명확화)
- 장황한 주석 블록 제거, 간결한 인라인 주석으로 교체
- `BlogClient`, `ProjectsClient` 동일 패턴 적용

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 프로덕션 빌드 성공 (`npm run build`)
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거