### PR TITLE
FRONT-16: fix: 블로그 포스트 본문 너비 복원

### DIFF
--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -181,7 +181,7 @@ export default function BlogPostClient({ post, from }: Props) {
       </header>
 
       {/* 본문 */}
-      <main className="mx-auto max-w-[1280px] px-4 py-6 sm:px-5 sm:py-10">
+      <main className={`mx-auto px-4 py-6 sm:px-5 sm:py-10 ${tocItems.length > 0 ? 'max-w-[1000px] xl:max-w-[1280px]' : 'max-w-[1000px]'}`}>
         <div className={tocItems.length > 0 ? 'xl:flex xl:items-start xl:gap-8' : ''}>
 
           {/* 콘텐츠 */}


### PR DESCRIPTION
## 관련 이슈
closes #45
Jira: FRONT-16

## 변경 유형
- [x] Bug fix

## 변경 내용
- `xl` 미만 화면에서 `max-w-[1000px]` 복원 (TOC는 이 구간에서 숨김 처리)
- `xl` 이상에서만 `max-w-[1280px]`로 확장 (TOC 사이드바 공간 확보)

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거