### PR TITLE
FRONT-18: fix: TOC 표시 breakpoint min-[1440px]로 상향

### DIFF
--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -182,7 +182,7 @@ export default function BlogPostClient({ post, from }: Props) {
 
       {/* 데스크톱 TOC - fixed 포지션, 본문 레이아웃과 무관 */}
       {tocItems.length > 0 && (
-        <aside className="hidden xl:block fixed top-36 w-48"
+        <aside className="hidden min-[1440px]:block fixed top-36 w-48"
           style={{ left: 'calc(50% + 520px)' }}
         >
           <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">


### PR DESCRIPTION
## 관련 이슈
closes #50
Jira: FRONT-18

## 변경 유형
- [x] Bug fix

## 변경 내용
- TOC 표시 조건: `xl:block`(1280px) → `min-[1440px]:block`(1440px)
- 1280~1423px 화면(1366px 노트북 등)에서 fixed TOC가 뷰포트를 넘어 가로 스크롤 유발하던 문제 해결
- 1440px 이상에서는 콘텐츠 우측에 충분한 여백(208px+)이 생겨 TOC 정상 표시

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음