### PR TITLE
FRONT-19: fix: 모바일 TOC breakpoint min-[1440px]:hidden으로 통일

### DIFF
--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -216,7 +216,7 @@ export default function BlogPostClient({ post, from }: Props) {
 
           {/* 모바일 TOC */}
           {tocItems.length > 0 && (
-            <div className="xl:hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="min-[1440px]:hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
               <button
                 onClick={() => setTocOpen((v) => !v)}
                 className="flex w-full items-center justify-between px-4 py-3.5 text-sm font-semibold text-gray-700 dark:text-gray-200"


### PR DESCRIPTION
## 관련 이슈
closes #52
Jira: FRONT-19

## 변경 유형
- [x] Bug fix

## 변경 내용
모바일 TOC `xl:hidden`(1280px) → `min-[1440px]:hidden`으로 변경

| 화면 너비 | 수정 전 | 수정 후 |
|---|---|---|
| < 1280px | 모바일 TOC 보임 ✅ | 모바일 TOC 보임 ✅ |
| 1280~1439px | 둘 다 숨김 ❌ | 모바일 TOC 보임 ✅ |
| ≥ 1440px | 데스크톱 TOC 보임 ✅ | 데스크톱 TOC 보임 ✅ |

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음