### PR TITLE
FRONT-20: refactor: 블로그 상세 페이지 2차 네비바 제거 및 헤더 통합

### DIFF
--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -116,38 +116,45 @@ export default function BlogPostClient({ post, from }: Props) {
         </div>
       )}
 
-      {/* 상단 네비게이션 */}
-      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-4 py-2.5 sm:px-5 sm:py-3">
-          <button onClick={handleBack} className="flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white sm:gap-1.5 sm:px-3 sm:text-sm">
-            <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-            {from === 'list' ? '목록으로' : 'Blog'}
-          </button>
-
-          {isAdmin && (
-            <div className="flex items-center gap-1.5 sm:gap-2">
-              <button onClick={() => router.push(`/blog/${post.id}/edit`)} className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 sm:gap-1.5 sm:px-3 sm:text-sm">
-                <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
-                수정
-              </button>
-              <button onClick={() => setShowDeleteConfirm(true)} className="flex items-center gap-1 rounded-lg border border-red-200 bg-white px-2.5 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20 sm:gap-1.5 sm:px-3 sm:text-sm">
-                <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-                삭제
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-
       {/* 헤더 */}
       <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
-        <div className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-10">
+        <div className="mx-auto max-w-[1000px] px-4 pt-5 pb-6 sm:px-5 sm:pt-7 sm:pb-10">
+          {/* 뒤로가기 + 관리자 액션 */}
+          <div className="mb-5 flex items-center justify-between sm:mb-6">
+            <button
+              onClick={handleBack}
+              className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+              {from === 'list' ? '목록으로' : 'Blog'}
+            </button>
+
+            {isAdmin && (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => router.push(`/blog/${post.id}/edit`)}
+                  className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                  수정
+                </button>
+                <button
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  삭제
+                </button>
+              </div>
+            )}
+          </div>
+
           {post.tags.length > 0 && (
             <div className="mb-4 flex flex-wrap gap-1.5 sm:mb-5 sm:gap-2">
               {post.tags.map((tag) => (


### PR DESCRIPTION
## 관련 이슈
closes #54
Jira: FRONT-20

## 변경 유형
- [x] Refactor

## 변경 내용

블로그 포스트 상세 페이지에서 sticky 2차 네비게이션 바를 제거하고, 뒤로가기·수정·삭제 버튼을 헤더 상단으로 통합.

**Before**: Navbar(72px) → sticky 2차 네비바 → 헤더 → 본문  
**After**: Navbar(72px) → 헤더(뒤로가기 + 관리자 버튼 포함) → 본문

- sticky `top-[72px]` 2차 네비바 div 제거
- 헤더 상단에 `← 목록으로` 버튼(좌) + 수정/삭제 버튼(우) 배치
- 기존 기능(handleBack, 수정, 삭제 확인 모달) 동일하게 유지

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거