### PR TITLE
release: develop → main (블로그 UX 개선, CI/CD, 코드 품질)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  lint-and-build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_API_URL: ${{ github.base_ref == 'main' && secrets.NEXT_PUBLIC_API_URL || secrets.NEXT_PUBLIC_API_URL_DEV }}
+          NEXT_PUBLIC_ADMIN_EMAILS: ${{ secrets.NEXT_PUBLIC_ADMIN_EMAILS }}

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ CLAUDE.md
 CLAUDE.local.md
 **/CLAUDE.md
 **/CLAUDE.local.md
+
+# AI Memory Bank
+.ai_docs/

--- a/app/api/[...path]/route.ts
+++ b/app/api/[...path]/route.ts
@@ -91,18 +91,19 @@ async function proxyRequest(
         'Content-Type': 'application/json',
       },
     })
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = error instanceof Error ? error : new Error(String(error))
     console.error('=== PROXY ERROR ===')
-    console.error('Error name:', error.name)
-    console.error('Error message:', error.message)
-    console.error('Error stack:', error.stack)
+    console.error('Error name:', err.name)
+    console.error('Error message:', err.message)
+    console.error('Error stack:', err.stack)
     console.error('=== ERROR END ===')
 
     return NextResponse.json(
       { 
         error: 'Proxy failed',
-        message: error.message,
-        name: error.name,
+        message: err.message,
+        name: err.name,
         url,
       },
       { status: 502 }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
       const supabase = await createClient()
 
       // OAuth 코드를 세션으로 교환
-      const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+      const { error } = await supabase.auth.exchangeCodeForSession(code)
 
       if (error) {
         console.error('[OAuth Callback] 에러:', error)
@@ -21,9 +21,10 @@ export async function GET(request: NextRequest) {
 
       // 성공 - 홈으로 리다이렉트
       return NextResponse.redirect(`${origin}`)
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
       console.error('[OAuth Callback] Exception:', err)
-      return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(err.message)}`)
+      return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(message)}`)
     }
   }
 

--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -19,11 +19,12 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  const pageFromUrl   = Number(searchParams.get('page'))   || 1
-  const searchFromUrl = searchParams.get('search') || ''
+  const pageFromUrl     = Number(searchParams.get('page'))     || 1
+  const searchFromUrl   = searchParams.get('search')   || ''
+  const categoryFromUrl = searchParams.get('category') || ''
 
-  // SSR initialData는 항상 page=1, 검색 없음 기준으로 받아옴
-  const isDefaultUrl = pageFromUrl === 1 && searchFromUrl === ''
+  // SSR initialData는 항상 page=1, 검색/카테고리 없음 기준으로 받아옴
+  const isDefaultUrl = pageFromUrl === 1 && searchFromUrl === '' && categoryFromUrl === ''
 
   const [posts, setPosts]             = useState<Post[]>(isDefaultUrl ? initialData.items : [])
   const [totalPages, setTotalPages]   = useState(isDefaultUrl ? initialData.totalPages : 1)
@@ -34,11 +35,12 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   // 최초 마운트 시 SSR 데이터를 그대로 쓰는 경우 fetch 스킵
   const hasMounted = useRef(false)
 
-  const loadPosts = useCallback(async (page: number, search: string) => {
+  const loadPosts = useCallback(async (page: number, search: string, category: string) => {
     try {
       setLoading(true)
-      const params: Record<string, unknown> = { page, limit: 10 }
-      if (search) params.search = search
+      const params: { page: number; limit: number; search?: string; category?: string } = { page, limit: 10 }
+      if (search)   params.search   = search
+      if (category) params.category = category
       const response = await getPosts(params)
       setPosts(response.items)
       setTotalPages(response.totalPages)
@@ -54,26 +56,35 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
       hasMounted.current = true
       if (isDefaultUrl) return  // 최초 진입, SSR 데이터로 충분
     }
-    loadPosts(pageFromUrl, searchFromUrl)
-  }, [pageFromUrl, searchFromUrl, isDefaultUrl, loadPosts])
+    loadPosts(pageFromUrl, searchFromUrl, categoryFromUrl)
+  }, [pageFromUrl, searchFromUrl, categoryFromUrl, isDefaultUrl, loadPosts])
 
-  const updateUrl = (page: number, search: string) => {
+  const updateUrl = (page: number, search: string, category: string) => {
     const params = new URLSearchParams()
-    if (page > 1)  params.set('page',   String(page))
-    if (search)    params.set('search', search)
+    if (page > 1)  params.set('page',     String(page))
+    if (search)    params.set('search',   search)
+    if (category)  params.set('category', category)
     const qs = params.toString()
     router.push(`/blog${qs ? `?${qs}` : ''}`, { scroll: false })
   }
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
-    updateUrl(1, searchInput)
+    updateUrl(1, searchInput, categoryFromUrl)
   }
 
   const handleClear = () => {
     setSearchInput('')
-    updateUrl(1, '')
+    updateUrl(1, '', categoryFromUrl)
   }
+
+  const CATEGORIES = [
+    { value: '',         label: '전체' },
+    { value: 'tutorial', label: '튜토리얼' },
+    { value: 'essay',    label: '에세이' },
+    { value: 'review',   label: '리뷰' },
+    { value: 'news',     label: '뉴스' },
+  ]
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -95,6 +106,24 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
               포스트 작성
             </Link>
           )}
+        </div>
+
+        {/* 카테고리 필터 */}
+        <div className="mb-5 flex flex-wrap gap-2">
+          {CATEGORIES.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => updateUrl(1, searchFromUrl, value)}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                categoryFromUrl === value
+                  ? 'bg-blue-600 text-white'
+                  : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
         </div>
 
         <form onSubmit={handleSearch} className="mb-7">
@@ -122,7 +151,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
           </div>
           {searchFromUrl && (
             <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
-              <span className="font-semibold text-gray-700 dark:text-gray-300">"{searchFromUrl}"</span> 검색 결과
+              <span className="font-semibold text-gray-700 dark:text-gray-300">{'"'}{searchFromUrl}{'"'}</span> 검색 결과
             </p>
           )}
         </form>
@@ -134,15 +163,22 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
         ) : posts.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-gray-200 py-24 text-center dark:border-gray-700">
             <p className="text-sm text-gray-400 dark:text-gray-500">
-              {searchFromUrl ? `"${searchFromUrl}"에 대한 결과가 없습니다.` : '포스트가 없습니다.'}
+              {searchFromUrl
+                ? `"${searchFromUrl}"에 대한 결과가 없습니다.`
+                : categoryFromUrl
+                  ? `해당 카테고리의 포스트가 없습니다.`
+                  : '포스트가 없습니다.'}
             </p>
-            {isAdmin && !searchFromUrl && (
+            {isAdmin && !searchFromUrl && !categoryFromUrl && (
               <Link href="/blog/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">
                 첫 포스트 작성하기
               </Link>
             )}
-            {searchFromUrl && (
-              <button onClick={handleClear} className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400">
+            {(searchFromUrl || categoryFromUrl) && (
+              <button
+                onClick={() => { setSearchInput(''); updateUrl(1, '', '') }}
+                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400"
+              >
                 전체 목록으로
               </button>
             )}
@@ -160,7 +196,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             {totalPages > 1 && (
               <div className="mt-10 flex items-center justify-center gap-2">
                 <button
-                  onClick={() => updateUrl(Math.max(1, pageFromUrl - 1), searchFromUrl)}
+                  onClick={() => updateUrl(Math.max(1, pageFromUrl - 1), searchFromUrl, categoryFromUrl)}
                   disabled={pageFromUrl === 1}
                   className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
                 >
@@ -172,7 +208,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                   {pageFromUrl} / {totalPages}
                 </span>
                 <button
-                  onClick={() => updateUrl(Math.min(totalPages, pageFromUrl + 1), searchFromUrl)}
+                  onClick={() => updateUrl(Math.min(totalPages, pageFromUrl + 1), searchFromUrl, categoryFromUrl)}
                   disabled={pageFromUrl === totalPages}
                   className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
                 >

--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { type Post } from '@/lib/api/posts'
 import { useAuth } from '@/hooks/useAuth'
@@ -12,6 +12,27 @@ import rehypeHighlight from 'rehype-highlight'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
 import api from '@/lib/api/client'
+import type { Components } from 'react-markdown'
+
+// 헤딩 텍스트 → anchor ID 변환
+const slugify = (text: string) =>
+  text.toLowerCase().trim().replace(/[^\w\s가-힣-]/g, '').replace(/\s+/g, '-')
+
+interface TocItem {
+  level: 2 | 3
+  text: string
+  id: string
+}
+
+function extractToc(content: string): TocItem[] {
+  return content
+    .split('\n')
+    .flatMap((line) => {
+      const m = line.match(/^(#{2,3})\s+(.+)/)
+      if (!m) return []
+      return [{ level: m[1].length as 2 | 3, text: m[2].trim(), id: slugify(m[2].trim()) }]
+    })
+}
 
 interface Props {
   post: Post
@@ -23,9 +44,29 @@ export default function BlogPostClient({ post, from }: Props) {
   const { isAdmin } = useAuth()
   const [deleting, setDeleting] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [readingProgress, setReadingProgress] = useState(0)
+  const [tocOpen, setTocOpen] = useState(false)
+
+  const tocItems = useMemo(() => extractToc(post.content), [post.content])
+
+  // 헤딩에 id 부여하는 커스텀 컴포넌트
+  const markdownComponents: Components = useMemo(() => ({
+    h2: ({ children }) => <h2 id={slugify(String(children))}>{children}</h2>,
+    h3: ({ children }) => <h3 id={slugify(String(children))}>{children}</h3>,
+  }), [])
+
+  useEffect(() => {
+    const updateProgress = () => {
+      const scrollTop = window.scrollY
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight
+      setReadingProgress(docHeight > 0 ? Math.min(100, (scrollTop / docHeight) * 100) : 0)
+    }
+    window.addEventListener('scroll', updateProgress, { passive: true })
+    return () => window.removeEventListener('scroll', updateProgress)
+  }, [])
 
   const handleBack = () => {
-    from === 'list' ? router.back() : router.push('/blog')
+    if (from === 'list') { router.back() } else { router.push('/blog') }
   }
 
   const handleDelete = async () => {
@@ -44,6 +85,14 @@ export default function BlogPostClient({ post, from }: Props) {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
+      {/* 읽기 진행바 */}
+      <div className="fixed left-0 top-0 z-50 h-[3px] w-full bg-transparent">
+        <div
+          className="h-full bg-blue-500 transition-[width] duration-100 ease-out dark:bg-blue-400"
+          style={{ width: `${readingProgress}%` }}
+        />
+      </div>
+
       {/* 삭제 확인 모달 */}
       {showDeleteConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 backdrop-blur-sm">
@@ -55,7 +104,7 @@ export default function BlogPostClient({ post, from }: Props) {
             </div>
             <h3 className="mb-2 text-base font-bold text-gray-900 dark:text-white sm:text-lg">포스트 삭제</h3>
             <p className="mb-5 text-xs text-gray-500 dark:text-gray-400 sm:mb-6 sm:text-sm">
-              <span className="font-medium text-gray-900 dark:text-white">"{post.title}"</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
+              <span className="font-medium text-gray-900 dark:text-white">{'"'}{post.title}{'"'}</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="flex gap-2.5 sm:gap-3">
               <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm">취소</button>
@@ -67,38 +116,45 @@ export default function BlogPostClient({ post, from }: Props) {
         </div>
       )}
 
-      {/* 상단 네비게이션 */}
-      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-4 py-2.5 sm:px-5 sm:py-3">
-          <button onClick={handleBack} className="flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white sm:gap-1.5 sm:px-3 sm:text-sm">
-            <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-            {from === 'list' ? '목록으로' : 'Blog'}
-          </button>
-
-          {isAdmin && (
-            <div className="flex items-center gap-1.5 sm:gap-2">
-              <button onClick={() => router.push(`/blog/${post.id}/edit`)} className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 sm:gap-1.5 sm:px-3 sm:text-sm">
-                <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
-                수정
-              </button>
-              <button onClick={() => setShowDeleteConfirm(true)} className="flex items-center gap-1 rounded-lg border border-red-200 bg-white px-2.5 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20 sm:gap-1.5 sm:px-3 sm:text-sm">
-                <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-                삭제
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-
       {/* 헤더 */}
       <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
-        <div className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-10">
+        <div className="mx-auto max-w-[1000px] px-4 pt-5 pb-6 sm:px-5 sm:pt-7 sm:pb-10">
+          {/* 뒤로가기 + 관리자 액션 */}
+          <div className="mb-5 flex items-center justify-between sm:mb-6">
+            <button
+              onClick={handleBack}
+              className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+              {from === 'list' ? '목록으로' : 'Blog'}
+            </button>
+
+            {isAdmin && (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => router.push(`/blog/${post.id}/edit`)}
+                  className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                  수정
+                </button>
+                <button
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  삭제
+                </button>
+              </div>
+            )}
+          </div>
+
           {post.tags.length > 0 && (
             <div className="mb-4 flex flex-wrap gap-1.5 sm:mb-5 sm:gap-2">
               {post.tags.map((tag) => (
@@ -131,12 +187,86 @@ export default function BlogPostClient({ post, from }: Props) {
         </div>
       </header>
 
-      {/* 본문 */}
+      {/* 데스크톱 TOC - fixed 포지션, 본문 레이아웃과 무관 */}
+      {tocItems.length > 0 && (
+        <aside className="hidden min-[1440px]:block fixed top-36 w-48"
+          style={{ left: 'calc(50% + 520px)' }}
+        >
+          <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <p className="mb-3 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+              <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h10M4 14h12M4 18h8" />
+              </svg>
+              목차
+            </p>
+            <nav>
+              <ul className="space-y-1.5">
+                {tocItems.map((item) => (
+                  <li key={item.id} className={item.level === 3 ? 'ml-3' : ''}>
+                    <a
+                      href={`#${item.id}`}
+                      className="block truncate text-sm text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+                    >
+                      {item.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </div>
+        </aside>
+      )}
+
+      {/* 본문 — 너비 원복 */}
       <main className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-10">
         <div className="space-y-5 sm:space-y-8">
+
+          {/* 모바일 TOC */}
+          {tocItems.length > 0 && (
+            <div className="min-[1440px]:hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <button
+                onClick={() => setTocOpen((v) => !v)}
+                className="flex w-full items-center justify-between px-4 py-3.5 text-sm font-semibold text-gray-700 dark:text-gray-200"
+              >
+                <span className="flex items-center gap-2">
+                  <svg className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h10M4 14h12M4 18h8" />
+                  </svg>
+                  목차
+                </span>
+                <svg className={`h-4 w-4 text-gray-400 transition-transform ${tocOpen ? 'rotate-180' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {tocOpen && (
+                <nav className="border-t border-gray-100 px-4 py-3 dark:border-gray-700">
+                  <ul className="space-y-1.5">
+                    {tocItems.map((item) => (
+                      <li key={item.id} className={item.level === 3 ? 'ml-4' : ''}>
+                        <a
+                          href={`#${item.id}`}
+                          onClick={() => setTocOpen(false)}
+                          className="block truncate text-sm text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+                        >
+                          {item.text}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+              )}
+            </div>
+          )}
+
           <section className="rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-6 sm:py-10 md:px-10 md:py-12">
             <div className="markdown-body">
-              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{post.content}</ReactMarkdown>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeHighlight]}
+                components={markdownComponents}
+              >
+                {post.content}
+              </ReactMarkdown>
             </div>
           </section>
 

--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -210,7 +210,7 @@ export default function EditPostPage() {
               <div className="mb-5 grid gap-5 sm:grid-cols-2">
                 <Field label="카테고리" required>
                   <select value={formData.category}
-                    onChange={(e) => setFormData({ ...formData, category: e.target.value as any })}
+                    onChange={(e) => setFormData({ ...formData, category: e.target.value as 'tutorial' | 'essay' | 'review' | 'news' })}
                     className={inputClass}>
                     <option value="tutorial">튜토리얼</option>
                     <option value="essay">에세이</option>

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -188,7 +188,7 @@ export default function NewPostPage() {
                 <Field label="카테고리" required>
                   <select
                     value={formData.category}
-                    onChange={(e) => setFormData({ ...formData, category: e.target.value as any })}
+                    onChange={(e) => setFormData({ ...formData, category: e.target.value as 'tutorial' | 'essay' | 'review' | 'news' })}
                     className={inputClass}
                   >
                     <option value="tutorial">튜토리얼</option>

--- a/app/debug/page.tsx
+++ b/app/debug/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState } from 'react'
+import type { Session } from '@supabase/supabase-js'
 import { createClient } from '@/lib/supabase/client'
 import api from '@/lib/api/client'
 
 export default function DebugPage() {
   const [logs, setLogs] = useState<string[]>([])
-  const [session, setSession] = useState<any>(null)
+  const [session, setSession] = useState<Session | null>(null)
 
   const addLog = (message: string) => {
     setLogs(prev => [...prev, `[${new Date().toLocaleTimeString()}] ${message}`])
@@ -36,8 +37,9 @@ export default function DebugPage() {
       const response = await api.get('/projects?page=1&limit=5')
       addLog(`✅ API 요청 성공: ${response.status}`)
       addLog(`📦 데이터: ${JSON.stringify(response.data).substring(0, 100)}...`)
-    } catch (error: any) {
-      addLog(`❌ API 요청 실패: ${error.statusCode} ${error.message}`)
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error))
+      addLog(`❌ API 요청 실패: ${err.message}`)
     }
   }
 
@@ -56,8 +58,9 @@ export default function DebugPage() {
       const response = await api.post('/projects', testProject)
       addLog(`✅ 인증 API 요청 성공: ${response.status}`)
       addLog(`📦 생성된 프로젝트 ID: ${response.data.id}`)
-    } catch (error: any) {
-      addLog(`❌ 인증 API 요청 실패: ${error.statusCode} ${error.message}`)
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error))
+      addLog(`❌ 인증 API 요청 실패: ${err.message}`)
     }
   }
 
@@ -167,10 +170,10 @@ export default function DebugPage() {
         <div className="mt-8 rounded-lg border-l-4 border-blue-500 bg-blue-50 p-6">
           <h3 className="mb-2 font-bold text-blue-900">💡 사용 방법</h3>
           <ol className="list-inside list-decimal space-y-1 text-sm text-blue-800">
-            <li>먼저 "세션 확인" 버튼으로 로그인 상태 확인</li>
-            <li>"Public API 테스트"로 인증 없이 작동하는 API 테스트</li>
-            <li>"인증 API 테스트"로 관리자 권한이 필요한 API 테스트</li>
-            <li>401 에러 발생 시 "세션 갱신" 버튼 클릭</li>
+            <li>먼저 {'"'}세션 확인{'"'} 버튼으로 로그인 상태 확인</li>
+            <li>{'"'}Public API 테스트{'"'}로 인증 없이 작동하는 API 테스트</li>
+            <li>{'"'}인증 API 테스트{'"'}로 관리자 권한이 필요한 API 테스트</li>
+            <li>401 에러 발생 시 {'"'}세션 갱신{'"'} 버튼 클릭</li>
             <li>브라우저 개발자 도구(F12) → Console 탭에서 상세 로그 확인</li>
           </ol>
         </div>
@@ -181,7 +184,7 @@ export default function DebugPage() {
           <ol className="list-inside list-decimal space-y-1 text-sm text-purple-800">
             <li>F12 키 또는 우클릭 → 검사</li>
             <li>Console 탭에서 상세 로그 확인</li>
-            <li>Network 탭 → Filter: "api" 입력</li>
+            <li>Network 탭 → Filter: {'"'}api{'"'} 입력</li>
             <li>요청 클릭 → Headers 탭 → Request Headers에서 Authorization 확인</li>
           </ol>
         </div>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import Link from 'next/link'
 
 interface Props {
   error: Error & { digest?: string }
@@ -35,12 +36,12 @@ export default function GlobalError({ error, reset }: Props) {
           >
             다시 시도
           </button>
-          <a
+          <Link
             href="/"
             className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             홈으로
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -71,15 +71,16 @@ function LoginForm() {
       
       router.push(redirectUrl)
       router.refresh()
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : ''
       console.error('❌ 로그인 실패:', err)
-      
-      if (err.message?.includes('Invalid login credentials')) {
+
+      if (message.includes('Invalid login credentials')) {
         setError('이메일 또는 비밀번호가 올바르지 않습니다.')
-      } else if (err.message?.includes('Email not confirmed')) {
+      } else if (message.includes('Email not confirmed')) {
         setError('이메일 인증이 필요합니다. 메일함을 확인해주세요.')
       } else {
-        setError(err.message || '로그인에 실패했습니다.')
+        setError(message || '로그인에 실패했습니다.')
       }
     } finally {
       setLoading(false)
@@ -90,7 +91,7 @@ function LoginForm() {
   const handleOAuthLogin = async (provider: 'google' | 'github' | 'kakao') => {
     setError('')
     try {
-      const { data, error } = await supabase.auth.signInWithOAuth({
+      const { error } = await supabase.auth.signInWithOAuth({
         provider: provider,
         options: {
           redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectUrl)}`,
@@ -101,13 +102,14 @@ function LoginForm() {
         console.error(`❌ ${provider} OAuth 에러:`, error)
         throw error
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : ''
       console.error(`${provider} login failed:`, err)
-      
-      if (err.message?.includes('provider is not enabled')) {
+
+      if (message.includes('provider is not enabled')) {
         setError(`${provider === 'kakao' ? '카카오톡' : provider === 'google' ? 'Google' : 'GitHub'} 로그인이 활성화되지 않았습니다.\n\nSupabase Dashboard에서 ${provider} Provider를 활성화해주세요.`)
       } else {
-        setError(`${provider} 로그인 실패: ${err.message}`)
+        setError(`${provider} 로그인 실패: ${message}`)
       }
     }
   }

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -32,7 +32,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
   const handleBack = () => {
-    from === 'list' ? router.back() : router.push('/projects')
+    if (from === 'list') { router.back() } else { router.push('/projects') }
   }
 
   const handleDelete = async () => {
@@ -64,7 +64,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
             </div>
             <h3 className="mb-2 text-lg font-bold text-gray-900 dark:text-white">프로젝트 삭제</h3>
             <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
-              <span className="font-medium text-gray-900 dark:text-white">"{project.title}"</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
+              <span className="font-medium text-gray-900 dark:text-white">{'"'}{project.title}{'"'}</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="flex gap-3">
               <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700">취소</button>

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -79,7 +79,7 @@ export default function EditProjectPage() {
     }
     try {
       setSubmitting(true)
-      const payload: Record<string, any> = {
+      const payload: Record<string, unknown> = {
         title: formData.title,
         summary: formData.summary,
         description: formData.description,
@@ -214,7 +214,7 @@ export default function EditProjectPage() {
               </Field>
               <Field label="상태">
                 <select value={formData.status}
-                  onChange={(e) => setFormData({ ...formData, status: e.target.value as any })}
+                  onChange={(e) => setFormData({ ...formData, status: e.target.value as 'in-progress' | 'completed' | 'archived' })}
                   className={inputClass}>
                   <option value="in-progress">진행중</option>
                   <option value="completed">완료</option>

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -47,7 +47,7 @@ export default function NewProjectPage() {
     }
     try {
       setSubmitting(true)
-      const payload: Record<string, any> = {
+      const payload: Record<string, unknown> = {
         title: formData.title,
         summary: formData.summary,
         description: formData.description,
@@ -183,7 +183,7 @@ export default function NewProjectPage() {
               <Field label="상태">
                 <select
                   value={formData.status}
-                  onChange={(e) => setFormData({ ...formData, status: e.target.value as any })}
+                  onChange={(e) => setFormData({ ...formData, status: e.target.value as 'in-progress' | 'completed' | 'archived' })}
                   className={inputClass}
                 >
                   <option value="in-progress">진행중</option>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -35,6 +35,7 @@ export default function Navbar() {
     return () => { document.body.style.overflow = '' }
   }, [mobileMenuOpen])
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setMobileMenuOpen(false) }, [pathname])
 
   const isActive = (href: string) => pathname.startsWith(href)

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -10,6 +10,7 @@ export function useTheme() {
     // 1순위: localStorage
     const saved = localStorage.getItem('theme')
     if (saved === 'dark' || saved === 'light') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setTheme(saved)
     } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
       // 2순위: OS 설정

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -99,7 +99,7 @@ export interface CreateProjectRequest {
   status?: ProjectStatus;
 }
 
-export interface UpdateProjectRequest extends Partial<CreateProjectRequest> {}
+export type UpdateProjectRequest = Partial<CreateProjectRequest>
 
 export interface GetProjectsRequest {
   page?: number;
@@ -143,12 +143,13 @@ export interface CreatePostRequest {
   tags?: string[];
 }
 
-export interface UpdatePostRequest extends Partial<CreatePostRequest> {}
+export type UpdatePostRequest = Partial<CreatePostRequest>
 
 export interface GetPostsRequest {
   page?: number;
   limit?: number;
   search?: string;
+  category?: string;
   tags?: string[];
 }
 


### PR DESCRIPTION
* chore: GitHub 이슈 및 PR 템플릿 추가

- ISSUE_TEMPLATE/bug_report.md
- ISSUE_TEMPLATE/feature_request.md
- PULL_REQUEST_TEMPLATE/feature.md
- PULL_REQUEST_TEMPLATE/release.md

* revert: .github 템플릿 커밋 되돌림 (main으로 이동 예정)

* chore: GitHub 이슈/PR 템플릿 및 라벨 정비 (#10)

- 이슈 템플릿: bug_report, feature_request, refactor, chore 추가/개선
- PR 템플릿: feature, release 개선 (변경 유형 체크리스트 추가)
- 라벨 추가: frontend, chore, refactor, hotfix, release, performance, security, ui/ux
- .gitignore에 .claude 추가

closes #9

* feat: 마크다운 코드 블록 syntax highlighting 적용 (#13)

- rehype-highlight 패키지 설치
- BlogPostClient, ProjectDetailClient에 rehypeHighlight 플러그인 추가
- layout.tsx에 highlight.js github-dark 테마 CSS 임포트
- globals.css 코드 블록 배경색을 github-dark 테마와 통일 (#0d1117)

closes #11

* fix: 로그인 페이지 /register 링크 제거 (#15)

OAuth 전용 인증 구조에서 불필요한 회원가입 링크를 제거하고
소셜 로그인으로 자동 가입됨을 안내하는 문구로 대체.

closes #14

* feat: SEO 메타데이터 및 Open Graph 태그 적용 (#17)

- layout.tsx: metadataBase, title template, 기본 OG/Twitter 태그 설정
- app/page.tsx: 홈 absolute title 및 OG 태그 추가
- app/blog/page.tsx: 블로그 목록 title/description/OG 추가
- app/blog/[id]/page.tsx: 포스트 제목·요약 기반 동적 메타데이터
- app/projects/page.tsx: 프로젝트 목록 title/description/OG 추가
- app/projects/[id]/page.tsx: 프로젝트 제목·요약 기반 동적 메타데이터

closes #16

* feat: Error Boundary 및 Not Found 페이지 추가 (#19)

- app/error.tsx: 전역 에러 경계 (다시 시도 / 홈으로 버튼)
- app/blog/error.tsx: 블로그 영역 에러 경계
- app/projects/error.tsx: 프로젝트 영역 에러 경계
- app/not-found.tsx: 404 페이지

Next.js App Router error.tsx 컨벤션을 활용하여
런타임 에러 발생 시 빈 화면 대신 안내 UI를 제공.

closes #18

* fix: document.referrer 기반 네비게이션 감지를 searchParams 방식으로 교체 (#21)

목록에서 상세 진입 시 ?from=list 쿼리 파라미터를 전달하고
서버 컴포넌트에서 searchParams로 읽어 클라이언트에 prop으로 주입.
document.referrer 의존성 및 관련 useRef/useEffect 제거.

closes #20

* fix: 하드코딩된 백엔드 IP 주소 제거 (#23)

NEXT_PUBLIC_API_URL 환경변수 미설정 시의 IP fallback 제거.
클라이언트 번들에 서버 IP가 노출되는 보안 이슈 해소.

closes #22

* fix: 로그인 페이지 오픈 리다이렉트 취약점 수정 (#29)

redirect 쿼리 파라미터가 내부 경로인지 검증하여
외부 URL로의 리다이렉트를 차단한다.

- '/'로 시작하지 않는 값 → '/'로 fallback
- '//'로 시작하는 프로토콜 상대 URL → '/'로 fallback
- 정상 내부 경로(/blog, /projects/123 등)는 그대로 허용

closes #24

* feat: img 태그를 Next.js Image 컴포넌트로 교체 (#31)

- PostCard, ProjectCard, ProjectDetailClient의 <img> → <Image> 교체
- fill + sizes 속성으로 lazy loading 및 WebP 자동 변환 적용
- next.config.ts에 cdn.jsdelivr.net, 백엔드 동적 호스트 remotePatterns 추가
- .gitignore에 CLAUDE.md, CLAUDE.local.md 추가

closes #26

* refactor: isInitialRender ref 워크어라운드 제거 및 코드 정리

closes #27

* FRONT-4: chore: Vercel Analytics 연동 (#33)

페이지 방문 통계 및 Web Vitals 수집을 위해 @vercel/analytics 패키지를 추가하고 루트 레이아웃에 Analytics 컴포넌트를 적용.

closes #28

* release: develop → main (isInitialRender 제거, Image 최적화, 보안패치, Analytics) (#34) (#35)

* chore: GitHub 이슈 및 PR 템플릿 추가

- ISSUE_TEMPLATE/bug_report.md
- ISSUE_TEMPLATE/feature_request.md
- PULL_REQUEST_TEMPLATE/feature.md
- PULL_REQUEST_TEMPLATE/release.md

* revert: .github 템플릿 커밋 되돌림 (main으로 이동 예정)

* chore: GitHub 이슈/PR 템플릿 및 라벨 정비 (#10)

- 이슈 템플릿: bug_report, feature_request, refactor, chore 추가/개선
- PR 템플릿: feature, release 개선 (변경 유형 체크리스트 추가)
- 라벨 추가: frontend, chore, refactor, hotfix, release, performance, security, ui/ux
- .gitignore에 .claude 추가

closes #9

* feat: 마크다운 코드 블록 syntax highlighting 적용 (#13)

- rehype-highlight 패키지 설치
- BlogPostClient, ProjectDetailClient에 rehypeHighlight 플러그인 추가
- layout.tsx에 highlight.js github-dark 테마 CSS 임포트
- globals.css 코드 블록 배경색을 github-dark 테마와 통일 (#0d1117)

closes #11

* fix: 로그인 페이지 /register 링크 제거 (#15)

OAuth 전용 인증 구조에서 불필요한 회원가입 링크를 제거하고
소셜 로그인으로 자동 가입됨을 안내하는 문구로 대체.

closes #14

* feat: SEO 메타데이터 및 Open Graph 태그 적용 (#17)

- layout.tsx: metadataBase, title template, 기본 OG/Twitter 태그 설정
- app/page.tsx: 홈 absolute title 및 OG 태그 추가
- app/blog/page.tsx: 블로그 목록 title/description/OG 추가
- app/blog/[id]/page.tsx: 포스트 제목·요약 기반 동적 메타데이터
- app/projects/page.tsx: 프로젝트 목록 title/description/OG 추가
- app/projects/[id]/page.tsx: 프로젝트 제목·요약 기반 동적 메타데이터

closes #16

* feat: Error Boundary 및 Not Found 페이지 추가 (#19)

- app/error.tsx: 전역 에러 경계 (다시 시도 / 홈으로 버튼)
- app/blog/error.tsx: 블로그 영역 에러 경계
- app/projects/error.tsx: 프로젝트 영역 에러 경계
- app/not-found.tsx: 404 페이지

Next.js App Router error.tsx 컨벤션을 활용하여
런타임 에러 발생 시 빈 화면 대신 안내 UI를 제공.

closes #18

* fix: document.referrer 기반 네비게이션 감지를 searchParams 방식으로 교체 (#21)

목록에서 상세 진입 시 ?from=list 쿼리 파라미터를 전달하고
서버 컴포넌트에서 searchParams로 읽어 클라이언트에 prop으로 주입.
document.referrer 의존성 및 관련 useRef/useEffect 제거.

closes #20

* fix: 하드코딩된 백엔드 IP 주소 제거 (#23)

NEXT_PUBLIC_API_URL 환경변수 미설정 시의 IP fallback 제거.
클라이언트 번들에 서버 IP가 노출되는 보안 이슈 해소.

closes #22

* fix: 로그인 페이지 오픈 리다이렉트 취약점 수정 (#29)

redirect 쿼리 파라미터가 내부 경로인지 검증하여
외부 URL로의 리다이렉트를 차단한다.

- '/'로 시작하지 않는 값 → '/'로 fallback
- '//'로 시작하는 프로토콜 상대 URL → '/'로 fallback
- 정상 내부 경로(/blog, /projects/123 등)는 그대로 허용

closes #24

* feat: img 태그를 Next.js Image 컴포넌트로 교체 (#31)

- PostCard, ProjectCard, ProjectDetailClient의 <img> → <Image> 교체
- fill + sizes 속성으로 lazy loading 및 WebP 자동 변환 적용
- next.config.ts에 cdn.jsdelivr.net, 백엔드 동적 호스트 remotePatterns 추가
- .gitignore에 CLAUDE.md, CLAUDE.local.md 추가

closes #26

* refactor: isInitialRender ref 워크어라운드 제거 및 코드 정리

closes #27

* FRONT-4: chore: Vercel Analytics 연동 (#33)

페이지 방문 통계 및 Web Vitals 수집을 위해 @vercel/analytics 패키지를 추가하고 루트 레이아웃에 Analytics 컴포넌트를 적용.

closes #28

* chore: 파비콘 변경

* FRONT-10: chore: GitHub Actions PR CI 워크플로우 추가

PR 생성/업데이트 시 lint와 build를 자동으로 검사하는
GitHub Actions 워크플로우 추가.

closes #36

* FRONT-10: chore: 기존 lint 에러 수정

CI 워크플로우 추가로 드러난 기존 lint 에러 34개 수정.
- no-explicit-any: catch 블록 및 payload 타입을 unknown으로 교체
- no-unescaped-entities: JSX 내 따옴표를 {'"'} 표현식으로 교체
- no-html-link-for-pages: error.tsx의 <a> 태그를 <Link>로 교체
- no-empty-object-type: 빈 interface를 type alias로 변환
- set-state-in-effect: eslint-disable 주석 추가 (초기화 목적의 유효한 패턴)
- no-unused-vars: 미사용 data 변수 제거

* FRONT-10: fix: 빌드 에러 수정 (unknown 타입 접근 오류)

error: unknown 변환 후 누락된 err 변수 참조 수정,
session 상태 타입을 Session | null으로 명시

* FRONT-10: chore: CI 빌드에 환경변수 주입 추가

GitHub Secrets에서 NEXT_PUBLIC_* 환경변수를 빌드 단계에 주입

* FRONT-10: chore: CI 브랜치별 API URL 분기 적용

main PR → NEXT_PUBLIC_API_URL (prod)
develop PR → NEXT_PUBLIC_API_URL_DEV (dev)

* FRONT-13: feat: 블로그 카테고리 필터 추가 (#40)

- BlogClient에 전체/튜토리얼/에세이/리뷰/뉴스 카테고리 버튼 추가
- URL searchParams(?category=tutorial)로 필터 상태 동기화
- 검색과 카테고리 필터 동시 적용 가능
- GetPostsRequest 타입에 category 필드 추가

closes #39

* FRONT-14: feat: 블로그 읽기 진행바 추가 (#43)

- 스크롤 위치 기반으로 상단에 3px 진행바 표시
- passive scroll 이벤트로 성능 최적화
- 다크모드 지원

closes #41

* FRONT-15: feat: 블로그 포스트 목차(TOC) 추가 (#44)

- 마크다운 h2/h3 헤딩 파싱해서 목차 자동 생성
- 데스크톱(xl): 우측 sticky 사이드바
- 모바일: 본문 상단 접이식 TOC 패널
- 커스텀 heading 컴포넌트로 각 헤딩에 id 부여해 앵커 링크 지원

closes #42

* FRONT-16: fix: 블로그 포스트 본문 너비 복원 (#46)

TOC 추가 후 xl 미만 화면에서도 max-w-[1280px]가 적용되던 문제 수정.
xl 미만에서는 기존과 동일한 max-w-[1000px] 유지.

closes #45

* FRONT-17: fix: 블로그 TOC를 fixed 포지션으로 변경해 본문 너비 완전 원복 (#48)

- TOC를 flex 레이아웃에서 분리, fixed 포지션으로 변경
- left: calc(50% + 520px) 로 콘텐츠 우측 여백에 배치
- 본문 컨테이너 max-w-[1000px] 완전 원복
- 모바일 TOC(xl 미만) 동작 유지

closes #47

* chore: .gitignore에 .ai_docs/ 추가 (#49)

* FRONT-18: fix: TOC 표시 breakpoint를 min-[1440px]로 상향 (#51)

xl(1280px) 이상에서 fixed TOC가 1280-1423px 화면의 뷰포트를
벗어나 가로 스크롤 유발하던 문제 수정.
TOC 표시 최소 너비를 1440px로 상향해 overflow 방지.

closes #50

* FRONT-19: fix: 모바일 TOC breakpoint를 min-[1440px]:hidden으로 통일 (#53)

데스크톱 TOC(min-[1440px]:block)와 모바일 TOC(xl:hidden) 불일치로 1280-1439px 화면에서 양쪽 모두 숨겨지던 문제 수정.

closes #52

* FRONT-20: refactor: 블로그 상세 페이지 2차 네비바 제거 및 헤더 통합 (#55)

뒤로가기·수정·삭제 버튼을 sticky 2차 네비바에서 헤더 상단으로 이동.
불필요한 UI 레이어를 제거하여 UX 단순화.

closes #54