### PR TITLE
FRONT-22: refactor: 에디터 페이지 디자인 통일 및 공통 UI 추출

### DIFF
--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -7,6 +7,8 @@ import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
 import { getPostById } from '@/lib/api/posts'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
+import FormField from '@/components/ui/FormField'
+import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -110,67 +112,66 @@ export default function EditPostPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
-      {/* Sticky 액션 바 */}
+      {/* 페이지 헤더 — 취소 + 제목 */}
+      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
+        <div className="mx-auto flex max-w-[1000px] items-center px-5 py-4">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            취소
+          </button>
+          <span className="ml-3 text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 수정</span>
+          {hasChanges && (
+            <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
+          )}
+        </div>
+      </header>
+
+      {/* Sticky 액션 바 — 편집/미리보기 + 저장 */}
       <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
-          <div className="flex items-center gap-3">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-end gap-2 px-5 py-2.5">
+          <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
             <button
               type="button"
-              onClick={handleCancel}
-              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+              onClick={() => setPreview(false)}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                !preview
+                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+              }`}
             >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-              취소
+              편집
             </button>
-            <div>
-              <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 수정</span>
-              {hasChanges && (
-                <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
-              )}
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
-              <button
-                type="button"
-                onClick={() => setPreview(false)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  !preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-                }`}
-              >
-                편집
-              </button>
-              <button
-                type="button"
-                onClick={() => setPreview(true)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-                }`}
-              >
-                미리보기
-              </button>
-            </div>
             <button
-              form="edit-post-form"
-              type="submit"
-              disabled={submitting || !hasChanges}
-              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              type="button"
+              onClick={() => setPreview(true)}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                preview
+                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+              }`}
             >
-              {submitting ? (
-                <>
-                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                  저장 중...
-                </>
-              ) : hasChanges ? '저장하기' : '변경사항 없음'}
+              미리보기
             </button>
           </div>
+          <button
+            form="edit-post-form"
+            type="submit"
+            disabled={submitting || !hasChanges}
+            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? (
+              <>
+                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                저장 중...
+              </>
+            ) : hasChanges ? '저장하기' : '변경사항 없음'}
+          </button>
         </div>
       </div>
 
@@ -187,18 +188,16 @@ export default function EditPostPage() {
         {!preview ? (
           <form id="edit-post-form" onSubmit={handleSubmit}>
             <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
-
-              <Field label="제목" required>
+              <FormField label="제목" required>
                 <input
                   type="text"
                   value={formData.title}
                   onChange={(e) => setFormData({ ...formData, title: e.target.value })}
                   placeholder="포스트 제목"
-                  className={`${inputClass} text-base font-semibold`}
+                  className={`${inputClass} font-semibold`}
                 />
-              </Field>
-
-              <Field label="요약" required>
+              </FormField>
+              <FormField label="요약" required>
                 <input
                   type="text"
                   value={formData.summary}
@@ -206,17 +205,15 @@ export default function EditPostPage() {
                   placeholder="한 줄 소개"
                   className={inputClass}
                 />
-              </Field>
-
-              <Field label="썸네일 이미지">
+              </FormField>
+              <FormField label="썸네일 이미지">
                 <ThumbnailUploader
                   value={formData.thumbnailUrl}
                   onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
                 />
-              </Field>
-
+              </FormField>
               <div className="mb-5 grid gap-5 sm:grid-cols-2">
-                <Field label="카테고리" required>
+                <FormField label="카테고리" required>
                   <select
                     value={formData.category}
                     onChange={(e) => setFormData({ ...formData, category: e.target.value as 'tutorial' | 'essay' | 'review' | 'news' })}
@@ -227,16 +224,15 @@ export default function EditPostPage() {
                     <option value="review">리뷰</option>
                     <option value="news">뉴스</option>
                   </select>
-                </Field>
-                <Field label="태그">
+                </FormField>
+                <FormField label="태그">
                   <TechStackInput
                     value={formData.tags}
                     onChange={(v) => setFormData({ ...formData, tags: v })}
                   />
-                </Field>
+                </FormField>
               </div>
-
-              <Field label="본문 (Markdown)" required>
+              <FormField label="본문 (Markdown)" required>
                 <textarea
                   value={formData.content}
                   rows={28}
@@ -247,7 +243,7 @@ export default function EditPostPage() {
                 <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
                   Markdown 문법을 지원합니다. 미리보기 탭에서 렌더링을 확인하세요.
                 </p>
-              </Field>
+              </FormField>
             </div>
           </form>
         ) : (
@@ -278,16 +274,3 @@ export default function EditPostPage() {
     </div>
   )
 }
-
-function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
-  return (
-    <div className="mb-5">
-      <label className="mb-1.5 block text-sm font-medium text-gray-600 dark:text-gray-400">
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
-      {children}
-    </div>
-  )
-}
-
-const inputClass = 'w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-gray-900 transition-colors focus:border-blue-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-blue-500 dark:focus:bg-gray-800/80'

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -6,9 +6,12 @@ import { useAuth } from '@/hooks/useAuth'
 import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
+import FormField from '@/components/ui/FormField'
+import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import rehypeHighlight from 'rehype-highlight'
 
 const EMPTY_FORM = {
   title: '',
@@ -83,14 +86,14 @@ export default function NewPostPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
-      {/* Sticky 액션 바 — navbar 바로 아래 */}
-      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
+      {/* 페이지 헤더 — 취소 + 제목 */}
+      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-4">
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={handleCancel}
-              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+              className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -98,48 +101,53 @@ export default function NewPostPage() {
               취소
             </button>
             <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 작성</span>
+            {hasChanges && (
+              <span className="text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
+            )}
           </div>
+        </div>
+      </header>
 
-          <div className="flex items-center gap-2">
-            {/* 편집 / 미리보기 토글 */}
-            <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
-              <button
-                type="button"
-                onClick={() => setPreview(false)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  !preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-                }`}
-              >
-                편집
-              </button>
-              <button
-                type="button"
-                onClick={() => setPreview(true)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-                }`}
-              >
-                미리보기
-              </button>
-            </div>
+      {/* Sticky 액션 바 — 편집/미리보기 + 저장 */}
+      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-end gap-2 px-5 py-2.5">
+          <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
             <button
-              form="new-post-form"
-              type="submit"
-              disabled={submitting}
-              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+              type="button"
+              onClick={() => setPreview(false)}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                !preview
+                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+              }`}
             >
-              {submitting ? (
-                <>
-                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                  저장 중...
-                </>
-              ) : '작성하기'}
+              편집
+            </button>
+            <button
+              type="button"
+              onClick={() => setPreview(true)}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                preview
+                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+              }`}
+            >
+              미리보기
             </button>
           </div>
+          <button
+            form="new-post-form"
+            type="submit"
+            disabled={submitting}
+            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+          >
+            {submitting ? (
+              <>
+                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                저장 중...
+              </>
+            ) : '작성하기'}
+          </button>
         </div>
       </div>
 
@@ -156,18 +164,16 @@ export default function NewPostPage() {
         {!preview ? (
           <form id="new-post-form" onSubmit={handleSubmit}>
             <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
-
-              <Field label="제목" required>
+              <FormField label="제목" required>
                 <input
                   type="text"
                   value={formData.title}
                   onChange={(e) => setFormData({ ...formData, title: e.target.value })}
                   placeholder="포스트 제목"
-                  className={`${inputClass} text-base font-semibold`}
+                  className={`${inputClass} font-semibold`}
                 />
-              </Field>
-
-              <Field label="요약" required>
+              </FormField>
+              <FormField label="요약" required>
                 <input
                   type="text"
                   value={formData.summary}
@@ -175,17 +181,15 @@ export default function NewPostPage() {
                   placeholder="한 줄 소개"
                   className={inputClass}
                 />
-              </Field>
-
-              <Field label="썸네일 이미지">
+              </FormField>
+              <FormField label="썸네일 이미지">
                 <ThumbnailUploader
                   value={formData.thumbnailUrl}
                   onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
                 />
-              </Field>
-
+              </FormField>
               <div className="mb-5 grid gap-5 sm:grid-cols-2">
-                <Field label="카테고리" required>
+                <FormField label="카테고리" required>
                   <select
                     value={formData.category}
                     onChange={(e) => setFormData({ ...formData, category: e.target.value as 'tutorial' | 'essay' | 'review' | 'news' })}
@@ -196,16 +200,15 @@ export default function NewPostPage() {
                     <option value="review">리뷰</option>
                     <option value="news">뉴스</option>
                   </select>
-                </Field>
-                <Field label="태그">
+                </FormField>
+                <FormField label="태그">
                   <TechStackInput
                     value={formData.tags}
                     onChange={(v) => setFormData({ ...formData, tags: v })}
                   />
-                </Field>
+                </FormField>
               </div>
-
-              <Field label="본문 (Markdown)" required>
+              <FormField label="본문 (Markdown)" required>
                 <textarea
                   value={formData.content}
                   rows={28}
@@ -216,7 +219,7 @@ export default function NewPostPage() {
                 <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
                   Markdown 문법을 지원합니다. 미리보기 탭에서 렌더링을 확인하세요.
                 </p>
-              </Field>
+              </FormField>
             </div>
           </form>
         ) : (
@@ -237,7 +240,9 @@ export default function NewPostPage() {
               {formData.summary || '요약 없음'}
             </p>
             <div className="markdown-body">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{formData.content || '*내용 없음*'}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                {formData.content || '*내용 없음*'}
+              </ReactMarkdown>
             </div>
           </div>
         )}
@@ -245,16 +250,3 @@ export default function NewPostPage() {
     </div>
   )
 }
-
-function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
-  return (
-    <div className="mb-5">
-      <label className="mb-1.5 block text-sm font-medium text-gray-600 dark:text-gray-400">
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
-      {children}
-    </div>
-  )
-}
-
-const inputClass = 'w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-gray-900 transition-colors focus:border-blue-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-blue-500 dark:focus:bg-gray-800/80'

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -7,6 +7,8 @@ import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
 import { getProject } from '@/lib/api/projects'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
+import FormField from '@/components/ui/FormField'
+import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 
 export default function EditProjectPage() {
@@ -108,8 +110,8 @@ export default function EditProjectPage() {
 
   if (!authReady || loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600" />
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-blue-600" />
       </div>
     )
   }
@@ -119,32 +121,34 @@ export default function EditProjectPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
-      {/* ── Sticky 저장 바 ── */}
-      <div className="sticky top-16 z-40 border-b border-gray-200/80 bg-white/90 backdrop-blur-md dark:border-gray-800/80 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-              취소
-            </button>
-            <div>
-              <span className="text-base font-semibold text-gray-900 dark:text-white">프로젝트 수정</span>
-              {hasChanges && (
-                <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
-              )}
-            </div>
-          </div>
+      {/* 페이지 헤더 — 취소 + 제목 */}
+      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
+        <div className="mx-auto flex max-w-[1000px] items-center px-5 py-4">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            취소
+          </button>
+          <span className="ml-3 text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 수정</span>
+          {hasChanges && (
+            <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
+          )}
+        </div>
+      </header>
+
+      {/* Sticky 액션 바 — 저장 */}
+      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-end px-5 py-2.5">
           <button
             form="edit-project-form"
             type="submit"
             disabled={submitting || !hasChanges}
-            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {submitting ? (
               <>
@@ -156,9 +160,9 @@ export default function EditProjectPage() {
         </div>
       </div>
 
-      <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <main className="mx-auto max-w-[1000px] px-5 py-8">
         {error && (
-          <div className="mb-6 flex items-start gap-3 rounded-xl bg-red-50 p-4 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+          <div className="mb-6 flex items-start gap-3 rounded-lg border border-red-100 bg-red-50 p-4 text-sm text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-400">
             <svg className="mt-0.5 h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
@@ -167,60 +171,82 @@ export default function EditProjectPage() {
         )}
 
         <form id="edit-project-form" onSubmit={handleSubmit}>
-          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-8">
-
-            <Field label="제목" required>
-              <input type="text" value={formData.title}
+          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+            <FormField label="제목" required>
+              <input
+                type="text"
+                value={formData.title}
                 onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                placeholder="프로젝트 제목" className={inputClass} />
-            </Field>
-
-            <Field label="요약" required>
-              <input type="text" value={formData.summary}
+                placeholder="프로젝트 제목"
+                className={`${inputClass} font-semibold`}
+              />
+            </FormField>
+            <FormField label="요약" required>
+              <input
+                type="text"
+                value={formData.summary}
                 onChange={(e) => setFormData({ ...formData, summary: e.target.value })}
-                placeholder="한 줄 소개" className={inputClass} />
-            </Field>
-
-            <Field label="상세 설명" required>
-              <textarea value={formData.description} rows={10}
+                placeholder="한 줄 소개"
+                className={inputClass}
+              />
+            </FormField>
+            <FormField label="상세 설명" required>
+              <textarea
+                value={formData.description}
+                rows={10}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="프로젝트 상세 설명" className={inputClass} />
-            </Field>
-
-            <Field label="기술 스택" required>
-              <TechStackInput value={formData.techStack} onChange={(v) => setFormData({ ...formData, techStack: v })} />
-            </Field>
-
-            <Field label="태그">
-              <TechStackInput value={formData.tags} onChange={(v) => setFormData({ ...formData, tags: v })} />
-            </Field>
-
+                placeholder="프로젝트 상세 설명"
+                className={inputClass}
+              />
+            </FormField>
+            <FormField label="기술 스택" required>
+              <TechStackInput
+                value={formData.techStack}
+                onChange={(v) => setFormData({ ...formData, techStack: v })}
+              />
+            </FormField>
+            <FormField label="태그">
+              <TechStackInput
+                value={formData.tags}
+                onChange={(v) => setFormData({ ...formData, tags: v })}
+              />
+            </FormField>
             <div className="grid gap-5 sm:grid-cols-2">
-              <Field label="썸네일 이미지">
+              <FormField label="썸네일 이미지">
                 <ThumbnailUploader
                   value={formData.thumbnailUrl}
                   onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
                 />
-              </Field>
-              <Field label="데모 URL">
-                <input type="url" value={formData.demoUrl}
-                  onChange={(e) => setFormData({ ...formData, demoUrl: e.target.value })}
-                  placeholder="https://demo.example.com" className={inputClass} />
-              </Field>
-              <Field label="GitHub URL">
-                <input type="url" value={formData.githubUrl}
-                  onChange={(e) => setFormData({ ...formData, githubUrl: e.target.value })}
-                  placeholder="https://github.com/username/repo" className={inputClass} />
-              </Field>
-              <Field label="상태">
-                <select value={formData.status}
+              </FormField>
+              <FormField label="상태">
+                <select
+                  value={formData.status}
                   onChange={(e) => setFormData({ ...formData, status: e.target.value as 'in-progress' | 'completed' | 'archived' })}
-                  className={inputClass}>
+                  className={inputClass}
+                >
                   <option value="in-progress">진행중</option>
                   <option value="completed">완료</option>
                   <option value="archived">보관</option>
                 </select>
-              </Field>
+              </FormField>
+              <FormField label="데모 URL">
+                <input
+                  type="url"
+                  value={formData.demoUrl}
+                  onChange={(e) => setFormData({ ...formData, demoUrl: e.target.value })}
+                  placeholder="https://demo.example.com"
+                  className={inputClass}
+                />
+              </FormField>
+              <FormField label="GitHub URL">
+                <input
+                  type="url"
+                  value={formData.githubUrl}
+                  onChange={(e) => setFormData({ ...formData, githubUrl: e.target.value })}
+                  placeholder="https://github.com/username/repo"
+                  className={inputClass}
+                />
+              </FormField>
             </div>
           </div>
         </form>
@@ -228,16 +254,3 @@ export default function EditProjectPage() {
     </div>
   )
 }
-
-function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
-  return (
-    <div className="mb-5">
-      <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
-      {children}
-    </div>
-  )
-}
-
-const inputClass = 'w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm transition-colors focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:focus:border-blue-500 dark:focus:bg-gray-800'

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -6,6 +6,8 @@ import { useAuth } from '@/hooks/useAuth'
 import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
+import FormField from '@/components/ui/FormField'
+import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 
 const EMPTY_FORM = {
@@ -84,22 +86,29 @@ export default function NewProjectPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
-      {/* Sticky 액션 바 — navbar 바로 아래 */}
+      {/* 페이지 헤더 — 취소 + 제목 */}
+      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
+        <div className="mx-auto flex max-w-[1000px] items-center px-5 py-4">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            취소
+          </button>
+          <span className="ml-3 text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 작성</span>
+          {hasChanges && (
+            <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
+          )}
+        </div>
+      </header>
+
+      {/* Sticky 액션 바 — 저장 */}
       <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-              취소
-            </button>
-            <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 작성</span>
-          </div>
+        <div className="mx-auto flex max-w-[1000px] items-center justify-end px-5 py-2.5">
           <button
             form="project-form"
             type="submit"
@@ -128,8 +137,7 @@ export default function NewProjectPage() {
 
         <form id="project-form" onSubmit={handleSubmit}>
           <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
-
-            <Field label="제목" required>
+            <FormField label="제목" required>
               <input
                 type="text"
                 value={formData.title}
@@ -137,9 +145,8 @@ export default function NewProjectPage() {
                 placeholder="프로젝트 제목"
                 className={`${inputClass} font-semibold`}
               />
-            </Field>
-
-            <Field label="요약" required>
+            </FormField>
+            <FormField label="요약" required>
               <input
                 type="text"
                 value={formData.summary}
@@ -147,9 +154,8 @@ export default function NewProjectPage() {
                 placeholder="한 줄 소개"
                 className={inputClass}
               />
-            </Field>
-
-            <Field label="상세 설명" required>
+            </FormField>
+            <FormField label="상세 설명" required>
               <textarea
                 value={formData.description}
                 rows={10}
@@ -157,30 +163,27 @@ export default function NewProjectPage() {
                 placeholder="프로젝트 상세 설명"
                 className={inputClass}
               />
-            </Field>
-
-            <Field label="기술 스택" required>
+            </FormField>
+            <FormField label="기술 스택" required>
               <TechStackInput
                 value={formData.techStack}
                 onChange={(v) => setFormData({ ...formData, techStack: v })}
               />
-            </Field>
-
-            <Field label="태그">
+            </FormField>
+            <FormField label="태그">
               <TechStackInput
                 value={formData.tags}
                 onChange={(v) => setFormData({ ...formData, tags: v })}
               />
-            </Field>
-
+            </FormField>
             <div className="grid gap-5 sm:grid-cols-2">
-              <Field label="썸네일 이미지">
+              <FormField label="썸네일 이미지">
                 <ThumbnailUploader
                   value={formData.thumbnailUrl}
                   onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
                 />
-              </Field>
-              <Field label="상태">
+              </FormField>
+              <FormField label="상태">
                 <select
                   value={formData.status}
                   onChange={(e) => setFormData({ ...formData, status: e.target.value as 'in-progress' | 'completed' | 'archived' })}
@@ -190,8 +193,8 @@ export default function NewProjectPage() {
                   <option value="completed">완료</option>
                   <option value="archived">보관</option>
                 </select>
-              </Field>
-              <Field label="데모 URL">
+              </FormField>
+              <FormField label="데모 URL">
                 <input
                   type="url"
                   value={formData.demoUrl}
@@ -199,8 +202,8 @@ export default function NewProjectPage() {
                   placeholder="https://demo.example.com"
                   className={inputClass}
                 />
-              </Field>
-              <Field label="GitHub URL">
+              </FormField>
+              <FormField label="GitHub URL">
                 <input
                   type="url"
                   value={formData.githubUrl}
@@ -208,7 +211,7 @@ export default function NewProjectPage() {
                   placeholder="https://github.com/username/repo"
                   className={inputClass}
                 />
-              </Field>
+              </FormField>
             </div>
           </div>
         </form>
@@ -216,16 +219,3 @@ export default function NewProjectPage() {
     </div>
   )
 }
-
-function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
-  return (
-    <div className="mb-5">
-      <label className="mb-1.5 block text-sm font-medium text-gray-600 dark:text-gray-400">
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
-      {children}
-    </div>
-  )
-}
-
-const inputClass = 'w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-gray-900 transition-colors focus:border-blue-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-blue-500 dark:focus:bg-gray-800/80'

--- a/components/ui/FormField.tsx
+++ b/components/ui/FormField.tsx
@@ -1,0 +1,16 @@
+interface FormFieldProps {
+  label: string
+  required?: boolean
+  children: React.ReactNode
+}
+
+export default function FormField({ label, required, children }: FormFieldProps) {
+  return (
+    <div className="mb-5">
+      <label className="mb-1.5 block text-sm font-medium text-gray-600 dark:text-gray-400">
+        {label} {required && <span className="text-red-500">*</span>}
+      </label>
+      {children}
+    </div>
+  )
+}

--- a/lib/styles/form.ts
+++ b/lib/styles/form.ts
@@ -1,0 +1,9 @@
+/**
+ * 폼 관련 공통 Tailwind 클래스
+ */
+
+export const inputClass =
+  'w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-gray-900 transition-colors ' +
+  'focus:border-blue-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 ' +
+  'dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 ' +
+  'dark:focus:border-blue-500 dark:focus:bg-gray-800/80'


### PR DESCRIPTION
## 관련 이슈
closes #61
Jira: FRONT-22

## 변경 유형
- [x] Refactor

## 변경 내용

**공통 UI 추출**
- `lib/styles/form.ts` — `inputClass` 단일 정의 (4개 파일에 분산되어 있던 것 통합)
- `components/ui/FormField.tsx` — label + children 래퍼 공통 컴포넌트

**4개 에디터 페이지 구조 통일** (blog/new, blog/edit, projects/new, projects/edit)
- 취소 버튼: sticky bar → 비고정 `<header>` 로 이동 (FRONT-20 블로그 뷰 패턴 적용)
- Sticky bar: 저장 버튼 + (블로그만) 편집/미리보기 토글만 남김
- `projects/edit`: `top-16` → `top-[72px]`, `max-w-4xl` → `max-w-[1000px]` 수정

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거