### PR TITLE
FRONT-22: refactor: EditorBar/Spinner/ErrorAlert 컴포넌트 추출 및 단일 sticky bar 통일

### DIFF
--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -112,66 +112,67 @@ export default function EditPostPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
-      {/* 페이지 헤더 — 취소 + 제목 */}
-      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
-        <div className="mx-auto flex max-w-[1000px] items-center px-5 py-4">
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-            취소
-          </button>
-          <span className="ml-3 text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 수정</span>
-          {hasChanges && (
-            <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
-          )}
-        </div>
-      </header>
-
-      {/* Sticky 액션 바 — 편집/미리보기 + 저장 */}
+      {/* 단일 Sticky 바 */}
       <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-end gap-2 px-5 py-2.5">
-          <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
+          {/* 왼쪽: 취소 + 제목 + 변경사항 */}
+          <div className="flex items-center gap-3 min-w-0">
             <button
               type="button"
-              onClick={() => setPreview(false)}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                !preview
-                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-              }`}
+              onClick={handleCancel}
+              className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
             >
-              편집
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+              취소
             </button>
+            <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
+            <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 수정</span>
+            {hasChanges && (
+              <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
+            )}
+          </div>
+          {/* 오른쪽: 편집/미리보기 + 저장 */}
+          <div className="flex shrink-0 items-center gap-2">
+            <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
+              <button
+                type="button"
+                onClick={() => setPreview(false)}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  !preview
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                편집
+              </button>
+              <button
+                type="button"
+                onClick={() => setPreview(true)}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  preview
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                미리보기
+              </button>
+            </div>
             <button
-              type="button"
-              onClick={() => setPreview(true)}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                preview
-                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-              }`}
+              form="edit-post-form"
+              type="submit"
+              disabled={submitting || !hasChanges}
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              미리보기
+              {submitting ? (
+                <>
+                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                  저장 중...
+                </>
+              ) : hasChanges ? '저장하기' : '변경사항 없음'}
             </button>
           </div>
-          <button
-            form="edit-post-form"
-            type="submit"
-            disabled={submitting || !hasChanges}
-            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {submitting ? (
-              <>
-                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                저장 중...
-              </>
-            ) : hasChanges ? '저장하기' : '변경사항 없음'}
-          </button>
         </div>
       </div>
 

--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -8,6 +8,9 @@ import { getPostById } from '@/lib/api/posts'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
 import FormField from '@/components/ui/FormField'
+import ErrorAlert from '@/components/ui/ErrorAlert'
+import Spinner from '@/components/ui/Spinner'
+import EditorBar from '@/components/EditorBar'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 import ReactMarkdown from 'react-markdown'
@@ -99,92 +102,23 @@ export default function EditPostPage() {
     router.push(`/blog/${postId}`)
   }
 
-  if (!authReady || loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-blue-600" />
-      </div>
-    )
-  }
-
+  if (!authReady || loading) return <Spinner />
   if (!isAdmin) return null
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-
-      {/* 단일 Sticky 바 */}
-      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
-          {/* 왼쪽: 취소 + 제목 + 변경사항 */}
-          <div className="flex items-center gap-3 min-w-0">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-              취소
-            </button>
-            <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
-            <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 수정</span>
-            {hasChanges && (
-              <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
-            )}
-          </div>
-          {/* 오른쪽: 편집/미리보기 + 저장 */}
-          <div className="flex shrink-0 items-center gap-2">
-            <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
-              <button
-                type="button"
-                onClick={() => setPreview(false)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  !preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-                }`}
-              >
-                편집
-              </button>
-              <button
-                type="button"
-                onClick={() => setPreview(true)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-                }`}
-              >
-                미리보기
-              </button>
-            </div>
-            <button
-              form="edit-post-form"
-              type="submit"
-              disabled={submitting || !hasChanges}
-              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {submitting ? (
-                <>
-                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                  저장 중...
-                </>
-              ) : hasChanges ? '저장하기' : '변경사항 없음'}
-            </button>
-          </div>
-        </div>
-      </div>
+      <EditorBar
+        title="포스트 수정"
+        hasChanges={hasChanges}
+        submitting={submitting}
+        onCancel={handleCancel}
+        formId="edit-post-form"
+        preview={preview}
+        onPreviewChange={setPreview}
+      />
 
       <main className="mx-auto max-w-[1000px] px-5 py-8">
-        {error && (
-          <div className="mb-6 flex items-start gap-3 rounded-lg border border-red-100 bg-red-50 p-4 text-sm text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-400">
-            <svg className="mt-0.5 h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            {error}
-          </div>
-        )}
+        {error && <ErrorAlert message={error} />}
 
         {!preview ? (
           <form id="edit-post-form" onSubmit={handleSubmit}>

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -7,6 +7,9 @@ import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
 import FormField from '@/components/ui/FormField'
+import ErrorAlert from '@/components/ui/ErrorAlert'
+import Spinner from '@/components/ui/Spinner'
+import EditorBar from '@/components/EditorBar'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 import ReactMarkdown from 'react-markdown'
@@ -75,90 +78,23 @@ export default function NewPostPage() {
     router.back()
   }
 
-  if (!authReady || !isAdmin) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-blue-600" />
-      </div>
-    )
-  }
+  if (!authReady || !isAdmin) return <Spinner />
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-
-      {/* 단일 Sticky 바 */}
-      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
-          {/* 왼쪽: 취소 + 제목 + 변경사항 */}
-          <div className="flex items-center gap-3 min-w-0">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-              취소
-            </button>
-            <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
-            <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 작성</span>
-            {hasChanges && (
-              <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
-            )}
-          </div>
-          {/* 오른쪽: 편집/미리보기 + 저장 */}
-          <div className="flex shrink-0 items-center gap-2">
-            <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
-              <button
-                type="button"
-                onClick={() => setPreview(false)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  !preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-                }`}
-              >
-                편집
-              </button>
-              <button
-                type="button"
-                onClick={() => setPreview(true)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-                }`}
-              >
-                미리보기
-              </button>
-            </div>
-            <button
-              form="new-post-form"
-              type="submit"
-              disabled={submitting}
-              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
-            >
-              {submitting ? (
-                <>
-                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                  저장 중...
-                </>
-              ) : '작성하기'}
-            </button>
-          </div>
-        </div>
-      </div>
+      <EditorBar
+        title="포스트 작성"
+        hasChanges={hasChanges}
+        submitting={submitting}
+        onCancel={handleCancel}
+        formId="new-post-form"
+        submitLabel="작성하기"
+        preview={preview}
+        onPreviewChange={setPreview}
+      />
 
       <main className="mx-auto max-w-[1000px] px-5 py-8">
-        {error && (
-          <div className="mb-6 flex items-start gap-3 rounded-lg border border-red-100 bg-red-50 p-4 text-sm text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-400">
-            <svg className="mt-0.5 h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            {error}
-          </div>
-        )}
+        {error && <ErrorAlert message={error} />}
 
         {!preview ? (
           <form id="new-post-form" onSubmit={handleSubmit}>

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -86,68 +86,67 @@ export default function NewPostPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
-      {/* 페이지 헤더 — 취소 + 제목 */}
-      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-4">
-          <div className="flex items-center gap-3">
+      {/* 단일 Sticky 바 */}
+      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
+          {/* 왼쪽: 취소 + 제목 + 변경사항 */}
+          <div className="flex items-center gap-3 min-w-0">
             <button
               type="button"
               onClick={handleCancel}
-              className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+              className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
               </svg>
               취소
             </button>
-            <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 작성</span>
+            <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
+            <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">포스트 작성</span>
             {hasChanges && (
-              <span className="text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
+              <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
             )}
           </div>
-        </div>
-      </header>
-
-      {/* Sticky 액션 바 — 편집/미리보기 + 저장 */}
-      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-end gap-2 px-5 py-2.5">
-          <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
+          {/* 오른쪽: 편집/미리보기 + 저장 */}
+          <div className="flex shrink-0 items-center gap-2">
+            <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
+              <button
+                type="button"
+                onClick={() => setPreview(false)}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  !preview
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                편집
+              </button>
+              <button
+                type="button"
+                onClick={() => setPreview(true)}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  preview
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                미리보기
+              </button>
+            </div>
             <button
-              type="button"
-              onClick={() => setPreview(false)}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                !preview
-                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-              }`}
+              form="new-post-form"
+              type="submit"
+              disabled={submitting}
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
             >
-              편집
-            </button>
-            <button
-              type="button"
-              onClick={() => setPreview(true)}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                preview
-                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-              }`}
-            >
-              미리보기
+              {submitting ? (
+                <>
+                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                  저장 중...
+                </>
+              ) : '작성하기'}
             </button>
           </div>
-          <button
-            form="new-post-form"
-            type="submit"
-            disabled={submitting}
-            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
-          >
-            {submitting ? (
-              <>
-                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                저장 중...
-              </>
-            ) : '작성하기'}
-          </button>
         </div>
       </div>
 

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -8,6 +8,9 @@ import { getProject } from '@/lib/api/projects'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
 import FormField from '@/components/ui/FormField'
+import ErrorAlert from '@/components/ui/ErrorAlert'
+import Spinner from '@/components/ui/Spinner'
+import EditorBar from '@/components/EditorBar'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 
@@ -108,66 +111,21 @@ export default function EditProjectPage() {
     router.push(`/projects/${params.id}`)
   }
 
-  if (!authReady || loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-blue-600" />
-      </div>
-    )
-  }
-
+  if (!authReady || loading) return <Spinner />
   if (!isAdmin) return null
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-
-      {/* 단일 Sticky 바 */}
-      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
-          {/* 왼쪽: 취소 + 제목 + 변경사항 */}
-          <div className="flex items-center gap-3 min-w-0">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-              취소
-            </button>
-            <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
-            <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 수정</span>
-            {hasChanges && (
-              <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
-            )}
-          </div>
-          {/* 오른쪽: 저장 */}
-          <button
-            form="edit-project-form"
-            type="submit"
-            disabled={submitting || !hasChanges}
-            className="flex shrink-0 items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {submitting ? (
-              <>
-                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                저장 중...
-              </>
-            ) : hasChanges ? '저장하기' : '변경사항 없음'}
-          </button>
-        </div>
-      </div>
+      <EditorBar
+        title="프로젝트 수정"
+        hasChanges={hasChanges}
+        submitting={submitting}
+        onCancel={handleCancel}
+        formId="edit-project-form"
+      />
 
       <main className="mx-auto max-w-[1000px] px-5 py-8">
-        {error && (
-          <div className="mb-6 flex items-start gap-3 rounded-lg border border-red-100 bg-red-50 p-4 text-sm text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-400">
-            <svg className="mt-0.5 h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            {error}
-          </div>
-        )}
+        {error && <ErrorAlert message={error} />}
 
         <form id="edit-project-form" onSubmit={handleSubmit}>
           <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -121,34 +121,33 @@ export default function EditProjectPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
-      {/* 페이지 헤더 — 취소 + 제목 */}
-      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
-        <div className="mx-auto flex max-w-[1000px] items-center px-5 py-4">
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-            취소
-          </button>
-          <span className="ml-3 text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 수정</span>
-          {hasChanges && (
-            <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
-          )}
-        </div>
-      </header>
-
-      {/* Sticky 액션 바 — 저장 */}
+      {/* 단일 Sticky 바 */}
       <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-end px-5 py-2.5">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
+          {/* 왼쪽: 취소 + 제목 + 변경사항 */}
+          <div className="flex items-center gap-3 min-w-0">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+              취소
+            </button>
+            <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
+            <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 수정</span>
+            {hasChanges && (
+              <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
+            )}
+          </div>
+          {/* 오른쪽: 저장 */}
           <button
             form="edit-project-form"
             type="submit"
             disabled={submitting || !hasChanges}
-            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex shrink-0 items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {submitting ? (
               <>

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -7,6 +7,9 @@ import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
 import FormField from '@/components/ui/FormField'
+import ErrorAlert from '@/components/ui/ErrorAlert'
+import Spinner from '@/components/ui/Spinner'
+import EditorBar from '@/components/EditorBar'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 
@@ -75,64 +78,21 @@ export default function NewProjectPage() {
     router.back()
   }
 
-  if (!authReady || !isAdmin) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-blue-600" />
-      </div>
-    )
-  }
+  if (!authReady || !isAdmin) return <Spinner />
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-
-      {/* 단일 Sticky 바 */}
-      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
-          {/* 왼쪽: 취소 + 제목 + 변경사항 */}
-          <div className="flex items-center gap-3 min-w-0">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-              취소
-            </button>
-            <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
-            <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 작성</span>
-            {hasChanges && (
-              <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
-            )}
-          </div>
-          {/* 오른쪽: 저장 */}
-          <button
-            form="project-form"
-            type="submit"
-            disabled={submitting}
-            className="flex shrink-0 items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
-          >
-            {submitting ? (
-              <>
-                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                저장 중...
-              </>
-            ) : '작성하기'}
-          </button>
-        </div>
-      </div>
+      <EditorBar
+        title="프로젝트 작성"
+        hasChanges={hasChanges}
+        submitting={submitting}
+        onCancel={handleCancel}
+        formId="project-form"
+        submitLabel="작성하기"
+      />
 
       <main className="mx-auto max-w-[1000px] px-5 py-8">
-        {error && (
-          <div className="mb-6 flex items-start gap-3 rounded-lg border border-red-100 bg-red-50 p-4 text-sm text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-400">
-            <svg className="mt-0.5 h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            {error}
-          </div>
-        )}
+        {error && <ErrorAlert message={error} />}
 
         <form id="project-form" onSubmit={handleSubmit}>
           <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -86,34 +86,33 @@ export default function NewProjectPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
-      {/* 페이지 헤더 — 취소 + 제목 */}
-      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
-        <div className="mx-auto flex max-w-[1000px] items-center px-5 py-4">
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-            취소
-          </button>
-          <span className="ml-3 text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 작성</span>
-          {hasChanges && (
-            <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">● 저장되지 않은 변경사항</span>
-          )}
-        </div>
-      </header>
-
-      {/* Sticky 액션 바 — 저장 */}
+      {/* 단일 Sticky 바 */}
       <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="mx-auto flex max-w-[1000px] items-center justify-end px-5 py-2.5">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
+          {/* 왼쪽: 취소 + 제목 + 변경사항 */}
+          <div className="flex items-center gap-3 min-w-0">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+              취소
+            </button>
+            <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
+            <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">프로젝트 작성</span>
+            {hasChanges && (
+              <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
+            )}
+          </div>
+          {/* 오른쪽: 저장 */}
           <button
             form="project-form"
             type="submit"
             disabled={submitting}
-            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+            className="flex shrink-0 items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
           >
             {submitting ? (
               <>

--- a/components/EditorBar.tsx
+++ b/components/EditorBar.tsx
@@ -1,0 +1,94 @@
+interface EditorBarProps {
+  title: string
+  hasChanges: boolean
+  submitting: boolean
+  onCancel: () => void
+  formId: string
+  submitLabel?: string
+  // 편집/미리보기 토글 (블로그 에디터에서만 사용)
+  preview?: boolean
+  onPreviewChange?: (v: boolean) => void
+}
+
+export default function EditorBar({
+  title,
+  hasChanges,
+  submitting,
+  onCancel,
+  formId,
+  submitLabel,
+  preview,
+  onPreviewChange,
+}: EditorBarProps) {
+  const hasPreviewToggle = preview !== undefined && onPreviewChange !== undefined
+
+  return (
+    <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
+      <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
+
+        {/* 왼쪽: 취소 + 구분선 + 제목 + 미저장 표시 */}
+        <div className="flex min-w-0 items-center gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            취소
+          </button>
+          <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
+          <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">{title}</span>
+          {hasChanges && (
+            <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
+          )}
+        </div>
+
+        {/* 오른쪽: 편집/미리보기 토글(선택) + 저장 버튼 */}
+        <div className="flex shrink-0 items-center gap-2">
+          {hasPreviewToggle && (
+            <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
+              <button
+                type="button"
+                onClick={() => onPreviewChange(false)}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  !preview
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                편집
+              </button>
+              <button
+                type="button"
+                onClick={() => onPreviewChange(true)}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  preview
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                미리보기
+              </button>
+            </div>
+          )}
+          <button
+            form={formId}
+            type="submit"
+            disabled={submitting || !hasChanges}
+            className="flex shrink-0 items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? (
+              <>
+                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                저장 중...
+              </>
+            ) : (submitLabel ?? (hasChanges ? '저장하기' : '변경사항 없음'))}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/components/ui/ErrorAlert.tsx
+++ b/components/ui/ErrorAlert.tsx
@@ -1,0 +1,14 @@
+interface ErrorAlertProps {
+  message: string
+}
+
+export default function ErrorAlert({ message }: ErrorAlertProps) {
+  return (
+    <div className="mb-6 flex items-start gap-3 rounded-lg border border-red-100 bg-red-50 p-4 text-sm text-red-600 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-400">
+      <svg className="mt-0.5 h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      {message}
+    </div>
+  )
+}

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -1,0 +1,14 @@
+interface SpinnerProps {
+  size?: 'sm' | 'md'
+}
+
+export default function Spinner({ size = 'md' }: SpinnerProps) {
+  const cls = size === 'sm'
+    ? 'h-8 w-8 border-[3px]'
+    : 'h-10 w-10 border-4'
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <div className={`${cls} animate-spin rounded-full border-gray-200 border-t-blue-600`} />
+    </div>
+  )
+}


### PR DESCRIPTION
## 관련 이슈
Jira: FRONT-22 (PR #62 후속 — 머지 타이밍 이슈로 누락된 커밋 반영)

## 변경 유형
- [x] Refactor

## 변경 내용

**공통 컴포넌트 추출**
- `components/EditorBar.tsx` — 단일 sticky bar (취소+제목+미저장+저장, 블로그는 편집/미리보기 토글 포함)
- `components/ui/Spinner.tsx` — 공통 로딩 스피너
- `components/ui/ErrorAlert.tsx` — 공통 에러 박스

**에디터 페이지 단일 bar 구조 통일**
- 2개 bar(header + sticky) → 1개 sticky bar로 재정리
- 4개 에디터 페이지 모두 `<EditorBar />` 컴포넌트 사용

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거