### PR TITLE
FRONT-23: refactor: Toast 알림 및 ConfirmDialog 도입으로 수정/삭제/취소 UX 개선

### DIFF
--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { type Post } from '@/lib/api/posts'
 import { useAuth } from '@/hooks/useAuth'
+import { useToast } from '@/hooks/useToast'
 import LikeButton from '@/components/LikeButton'
 import CommentSection from '@/components/CommentSection'
 import ReactMarkdown from 'react-markdown'
@@ -42,6 +43,7 @@ interface Props {
 export default function BlogPostClient({ post, from }: Props) {
   const router = useRouter()
   const { isAdmin } = useAuth()
+  const { showToast } = useToast()
   const [deleting, setDeleting] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [readingProgress, setReadingProgress] = useState(0)
@@ -73,10 +75,11 @@ export default function BlogPostClient({ post, from }: Props) {
     try {
       setDeleting(true)
       await api.delete(`/posts/${post.id}`)
+      showToast('포스트가 삭제되었습니다.')
       router.push('/blog')
-    } catch (err) {
-      console.error('Failed to delete post:', err)
+    } catch {
       setShowDeleteConfirm(false)
+      showToast('삭제에 실패했습니다. 다시 시도해주세요.', 'error')
     } finally {
       setDeleting(false)
     }
@@ -109,52 +112,59 @@ export default function BlogPostClient({ post, from }: Props) {
             <div className="flex gap-2.5 sm:gap-3">
               <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm">취소</button>
               <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60 sm:py-2.5 sm:text-sm">
-                {deleting ? '삭제 중...' : '삭제'}
+                {deleting ? (
+                  <span className="flex items-center justify-center gap-1.5">
+                    <span className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                    삭제 중...
+                  </span>
+                ) : '삭제'}
               </button>
             </div>
           </div>
         </div>
       )}
 
+      {/* sticky 네비 바 (뒤로가기 + 관리자 액션) */}
+      <div className="sticky top-[72px] z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90">
+        <div className="mx-auto flex max-w-[1000px] items-center justify-between px-4 py-3 sm:px-5">
+          <button
+            onClick={handleBack}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            {from === 'list' ? '목록으로' : 'Blog'}
+          </button>
+
+          {isAdmin && (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => router.push(`/blog/${post.id}/edit`)}
+                className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+                수정
+              </button>
+              <button
+                onClick={() => setShowDeleteConfirm(true)}
+                className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+                삭제
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
       {/* 헤더 */}
       <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
         <div className="mx-auto max-w-[1000px] px-4 pt-5 pb-6 sm:px-5 sm:pt-7 sm:pb-10">
-          {/* 뒤로가기 + 관리자 액션 */}
-          <div className="mb-5 flex items-center justify-between sm:mb-6">
-            <button
-              onClick={handleBack}
-              className="flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-              {from === 'list' ? '목록으로' : 'Blog'}
-            </button>
-
-            {isAdmin && (
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => router.push(`/blog/${post.id}/edit`)}
-                  className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
-                >
-                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
-                  수정
-                </button>
-                <button
-                  onClick={() => setShowDeleteConfirm(true)}
-                  className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20"
-                >
-                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                  삭제
-                </button>
-              </div>
-            )}
-          </div>
-
           {post.tags.length > 0 && (
             <div className="mb-4 flex flex-wrap gap-1.5 sm:mb-5 sm:gap-2">
               {post.tags.map((tag) => (
@@ -217,7 +227,7 @@ export default function BlogPostClient({ post, from }: Props) {
         </aside>
       )}
 
-      {/* 본문 — 너비 원복 */}
+      {/* 본문 */}
       <main className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-10">
         <div className="space-y-5 sm:space-y-8">
 

--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
+import { useToast } from '@/hooks/useToast'
 import { getPostById } from '@/lib/api/posts'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
@@ -11,6 +12,7 @@ import FormField from '@/components/ui/FormField'
 import ErrorAlert from '@/components/ui/ErrorAlert'
 import Spinner from '@/components/ui/Spinner'
 import EditorBar from '@/components/EditorBar'
+import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 import ReactMarkdown from 'react-markdown'
@@ -21,11 +23,13 @@ export default function EditPostPage() {
   const params = useParams()
   const router = useRouter()
   const { isAdmin, authReady } = useAuth()
+  const { showToast } = useToast()
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [preview, setPreview] = useState(false)
   const [postId, setPostId] = useState('')
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false)
 
   const [formData, setFormData] = useState({
     title: '',
@@ -88,6 +92,7 @@ export default function EditPostPage() {
         tags: formData.tags.length > 0 ? formData.tags : undefined,
         ...(formData.thumbnailUrl ? { thumbnailUrl: formData.thumbnailUrl } : {}),
       })
+      showToast('포스트가 수정되었습니다.')
       router.replace(`/blog/${postId}`)
     } catch (err: unknown) {
       const e = err as { message?: string | string[] }
@@ -98,7 +103,10 @@ export default function EditPostPage() {
   }
 
   const handleCancel = () => {
-    if (hasChanges && !confirm('변경사항이 저장되지 않았습니다. 취소할까요?')) return
+    if (hasChanges) {
+      setShowCancelConfirm(true)
+      return
+    }
     router.push(`/blog/${postId}`)
   }
 
@@ -107,6 +115,17 @@ export default function EditPostPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <ConfirmDialog
+        open={showCancelConfirm}
+        title="수정 취소"
+        description="변경사항이 저장되지 않습니다. 취소할까요?"
+        confirmLabel="취소하기"
+        cancelLabel="계속 수정"
+        variant="warning"
+        onConfirm={() => router.push(`/blog/${postId}`)}
+        onCancel={() => setShowCancelConfirm(false)}
+      />
+
       <EditorBar
         title="포스트 수정"
         hasChanges={hasChanges}

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -4,12 +4,14 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
+import { useToast } from '@/hooks/useToast'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
 import FormField from '@/components/ui/FormField'
 import ErrorAlert from '@/components/ui/ErrorAlert'
 import Spinner from '@/components/ui/Spinner'
 import EditorBar from '@/components/EditorBar'
+import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 import ReactMarkdown from 'react-markdown'
@@ -28,10 +30,12 @@ const EMPTY_FORM = {
 export default function NewPostPage() {
   const router = useRouter()
   const { isAdmin, authReady } = useAuth()
+  const { showToast } = useToast()
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [preview, setPreview] = useState(false)
   const [formData, setFormData] = useState(EMPTY_FORM)
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false)
 
   const hasChanges = JSON.stringify(formData) !== JSON.stringify(EMPTY_FORM)
   useUnsavedWarning(hasChanges)
@@ -57,6 +61,7 @@ export default function NewPostPage() {
         tags: formData.tags.length > 0 ? formData.tags : undefined,
         ...(formData.thumbnailUrl ? { thumbnailUrl: formData.thumbnailUrl } : {}),
       })
+      showToast('포스트가 작성되었습니다.')
       router.replace('/blog')
     } catch (err: unknown) {
       const e = err as { statusCode?: number; message?: string }
@@ -74,7 +79,10 @@ export default function NewPostPage() {
   }
 
   const handleCancel = () => {
-    if (hasChanges && !confirm('작성을 취소할까요? 입력한 내용이 사라집니다.')) return
+    if (hasChanges) {
+      setShowCancelConfirm(true)
+      return
+    }
     router.back()
   }
 
@@ -82,6 +90,17 @@ export default function NewPostPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <ConfirmDialog
+        open={showCancelConfirm}
+        title="작성 취소"
+        description="입력한 내용이 모두 사라집니다. 취소할까요?"
+        confirmLabel="취소하기"
+        cancelLabel="계속 작성"
+        variant="warning"
+        onConfirm={() => router.back()}
+        onCancel={() => setShowCancelConfirm(false)}
+      />
+
       <EditorBar
         title="포스트 작성"
         hasChanges={hasChanges}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "highlight.js/styles/github-dark.css";
 import Navbar from "@/components/Navbar";
+import { ToastProvider } from "@/components/ui/Toast";
 import { Analytics } from "@vercel/analytics/next";
 
 const geistSans = Geist({
@@ -67,9 +68,11 @@ export default function RootLayout({
         />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Navbar />
-        <div className="pt-[72px]">{children}</div>
-        <Analytics />
+        <ToastProvider>
+          <Navbar />
+          <div className="pt-[72px]">{children}</div>
+          <Analytics />
+        </ToastProvider>
       </body>
     </html>
   );

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -13,6 +13,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
 import Image from 'next/image'
 import api from '@/lib/api/client'
+import { useToast } from '@/hooks/useToast'
 
 interface Props {
   project: Project
@@ -28,6 +29,7 @@ const statusConfig = {
 export default function ProjectDetailClient({ project, from }: Props) {
   const router = useRouter()
   const { isAdmin } = useAuth()
+  const { showToast } = useToast()
   const [deleting, setDeleting] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
@@ -39,10 +41,11 @@ export default function ProjectDetailClient({ project, from }: Props) {
     try {
       setDeleting(true)
       await api.delete(`/projects/${project.id}`)
+      showToast('프로젝트가 삭제되었습니다.')
       router.push('/projects')
-    } catch (err) {
-      console.error('Failed to delete project:', err)
+    } catch {
       setShowDeleteConfirm(false)
+      showToast('삭제에 실패했습니다. 다시 시도해주세요.', 'error')
     } finally {
       setDeleting(false)
     }
@@ -69,7 +72,12 @@ export default function ProjectDetailClient({ project, from }: Props) {
             <div className="flex gap-3">
               <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700">취소</button>
               <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60">
-                {deleting ? '삭제 중...' : '삭제'}
+                {deleting ? (
+                  <span className="flex items-center justify-center gap-1.5">
+                    <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                    삭제 중...
+                  </span>
+                ) : '삭제'}
               </button>
             </div>
           </div>

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
+import { useToast } from '@/hooks/useToast'
 import { getProject } from '@/lib/api/projects'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
@@ -11,6 +12,7 @@ import FormField from '@/components/ui/FormField'
 import ErrorAlert from '@/components/ui/ErrorAlert'
 import Spinner from '@/components/ui/Spinner'
 import EditorBar from '@/components/EditorBar'
+import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 
@@ -18,9 +20,11 @@ export default function EditProjectPage() {
   const params = useParams()
   const router = useRouter()
   const { isAdmin, authReady } = useAuth()
+  const { showToast } = useToast()
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false)
 
   const [formData, setFormData] = useState({
     title: '',
@@ -97,6 +101,7 @@ export default function EditProjectPage() {
       if (formData.tags.length > 0) payload.tags = formData.tags
 
       await api.patch(`/projects/${params.id}`, payload)
+      showToast('프로젝트가 수정되었습니다.')
       router.replace(`/projects/${params.id}`)
     } catch (err: unknown) {
       const e = err as { message?: string | string[] }
@@ -107,7 +112,10 @@ export default function EditProjectPage() {
   }
 
   const handleCancel = () => {
-    if (hasChanges && !confirm('변경사항이 저장되지 않았습니다. 취소할까요?')) return
+    if (hasChanges) {
+      setShowCancelConfirm(true)
+      return
+    }
     router.push(`/projects/${params.id}`)
   }
 
@@ -116,6 +124,17 @@ export default function EditProjectPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <ConfirmDialog
+        open={showCancelConfirm}
+        title="수정 취소"
+        description="변경사항이 저장되지 않습니다. 취소할까요?"
+        confirmLabel="취소하기"
+        cancelLabel="계속 수정"
+        variant="warning"
+        onConfirm={() => router.push(`/projects/${params.id}`)}
+        onCancel={() => setShowCancelConfirm(false)}
+      />
+
       <EditorBar
         title="프로젝트 수정"
         hasChanges={hasChanges}

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -4,12 +4,14 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
+import { useToast } from '@/hooks/useToast'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
 import FormField from '@/components/ui/FormField'
 import ErrorAlert from '@/components/ui/ErrorAlert'
 import Spinner from '@/components/ui/Spinner'
 import EditorBar from '@/components/EditorBar'
+import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
 
@@ -28,9 +30,11 @@ const EMPTY_FORM = {
 export default function NewProjectPage() {
   const router = useRouter()
   const { isAdmin, authReady } = useAuth()
+  const { showToast } = useToast()
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [formData, setFormData] = useState(EMPTY_FORM)
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false)
 
   const hasChanges = JSON.stringify(formData) !== JSON.stringify(EMPTY_FORM)
   useUnsavedWarning(hasChanges)
@@ -64,6 +68,7 @@ export default function NewProjectPage() {
       if (formData.githubUrl) payload.githubUrl = formData.githubUrl
       if (formData.tags.length > 0) payload.tags = formData.tags
       await api.post('/projects', payload)
+      showToast('프로젝트가 작성되었습니다.')
       router.replace('/projects')
     } catch (err: unknown) {
       const e = err as { statusCode?: number; message?: string | string[] }
@@ -74,7 +79,10 @@ export default function NewProjectPage() {
   }
 
   const handleCancel = () => {
-    if (hasChanges && !confirm('작성을 취소할까요? 입력한 내용이 사라집니다.')) return
+    if (hasChanges) {
+      setShowCancelConfirm(true)
+      return
+    }
     router.back()
   }
 
@@ -82,6 +90,17 @@ export default function NewProjectPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <ConfirmDialog
+        open={showCancelConfirm}
+        title="작성 취소"
+        description="입력한 내용이 모두 사라집니다. 취소할까요?"
+        confirmLabel="취소하기"
+        cancelLabel="계속 작성"
+        variant="warning"
+        onConfirm={() => router.back()}
+        onCancel={() => setShowCancelConfirm(false)}
+      />
+
       <EditorBar
         title="프로젝트 작성"
         hasChanges={hasChanges}

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,77 @@
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'danger' | 'warning' | 'default'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = '확인',
+  cancelLabel = '취소',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  if (!open) return null
+
+  const confirmBtnClass = {
+    danger: 'bg-red-600 hover:bg-red-700 text-white',
+    warning: 'bg-amber-500 hover:bg-amber-600 text-white',
+    default: 'bg-blue-600 hover:bg-blue-700 text-white',
+  }[variant]
+
+  const iconMap = {
+    danger: (
+      <div className="flex h-11 w-11 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+        <svg className="h-5 w-5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        </svg>
+      </div>
+    ),
+    warning: (
+      <div className="flex h-11 w-11 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+        <svg className="h-5 w-5 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        </svg>
+      </div>
+    ),
+    default: null,
+  }[variant]
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 backdrop-blur-sm"
+      onClick={onCancel}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl dark:bg-gray-800 sm:p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {iconMap && <div className="mb-4">{iconMap}</div>}
+        <h3 className="mb-2 text-base font-bold text-gray-900 dark:text-white sm:text-lg">{title}</h3>
+        <p className="mb-5 text-xs text-gray-500 dark:text-gray-400 sm:mb-6 sm:text-sm">{description}</p>
+        <div className="flex gap-2.5 sm:gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className={`flex-1 rounded-xl px-4 py-2 text-xs font-semibold transition-colors sm:py-2.5 sm:text-sm ${confirmBtnClass}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ToastContext, useToastState, type Toast } from '@/hooks/useToast'
+
+// 개별 토스트 아이템
+function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: () => void }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // mount 후 한 프레임 뒤에 fade-in
+    const raf = requestAnimationFrame(() => setVisible(true))
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
+  const iconMap = {
+    success: (
+      <svg className="h-4 w-4 shrink-0 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+    ),
+    error: (
+      <svg className="h-4 w-4 shrink-0 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    ),
+    warning: (
+      <svg className="h-4 w-4 shrink-0 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+      </svg>
+    ),
+  }
+
+  const barColorMap = {
+    success: 'bg-emerald-500',
+    error: 'bg-red-500',
+    warning: 'bg-amber-500',
+  }
+
+  return (
+    <div
+      className={`relative flex w-full max-w-sm items-start gap-3 overflow-hidden rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-lg transition-all duration-300 dark:border-gray-700 dark:bg-gray-800 ${
+        visible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
+      }`}
+    >
+      {/* 왼쪽 컬러 바 */}
+      <div className={`absolute left-0 top-0 h-full w-1 rounded-l-xl ${barColorMap[toast.type]}`} />
+      <div className="ml-1 mt-0.5">{iconMap[toast.type]}</div>
+      <p className="flex-1 text-sm font-medium text-gray-800 dark:text-gray-200">{toast.message}</p>
+      <button
+        onClick={onRemove}
+        className="mt-0.5 shrink-0 text-gray-400 transition-colors hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+        aria-label="닫기"
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
+// Provider: layout.tsx에서 감싸기
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const value = useToastState()
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastContainer toasts={value.toasts} onRemove={value.removeToast} />
+    </ToastContext.Provider>
+  )
+}
+
+// 고정 컨테이너
+function ToastContainer({
+  toasts,
+  onRemove,
+}: {
+  toasts: ReturnType<typeof useToastState>['toasts']
+  onRemove: (id: string) => void
+}) {
+  if (toasts.length === 0) return null
+  return (
+    <div className="fixed bottom-6 right-4 z-[100] flex flex-col items-end gap-2 sm:right-6">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onRemove={() => onRemove(t.id)} />
+      ))}
+    </div>
+  )
+}

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { createContext, useContext, useState, useCallback, useRef } from 'react'
+
+export type ToastType = 'success' | 'error' | 'warning'
+
+export interface Toast {
+  id: string
+  message: string
+  type: ToastType
+}
+
+interface ToastContextValue {
+  toasts: Toast[]
+  showToast: (message: string, type?: ToastType) => void
+  removeToast: (id: string) => void
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function useToastState(): ToastContextValue {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const timerMap = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+    const timer = timerMap.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      timerMap.current.delete(id)
+    }
+  }, [])
+
+  const showToast = useCallback(
+    (message: string, type: ToastType = 'success') => {
+      const id = `${Date.now()}-${Math.random()}`
+      setToasts((prev) => [...prev, { id, message, type }])
+      const timer = setTimeout(() => removeToast(id), 3000)
+      timerMap.current.set(id, timer)
+    },
+    [removeToast],
+  )
+
+  return { toasts, showToast, removeToast }
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within ToastProvider')
+  return ctx
+}


### PR DESCRIPTION
## 관련 이슈
closes #65
Jira: FRONT-23

## 변경 유형
- [x] Refactor (코드 구조 개선, 기능 변경 없음)

## 변경 내용

### 신규 컴포넌트
- `hooks/useToast.ts` — Context 기반 Toast 시스템 (success/error/warning, 3초 자동 소멸, 클릭으로 닫기)
- `components/ui/Toast.tsx` — Toast UI 컴포넌트 + ToastProvider
- `components/ui/ConfirmDialog.tsx` — `window.confirm()` 대체 커스텀 확인 다이얼로그

### 수정 파일
- `app/layout.tsx` — ToastProvider 적용
- `blog/new`, `blog/edit`, `projects/new`, `projects/edit` — `window.confirm()` → ConfirmDialog 교체, 저장/작성 성공 toast 추가
- `BlogPostClient.tsx` — 뒤로가기/수정/삭제 버튼을 sticky 네비 바로 통일, 삭제 성공/실패 toast 추가
- `ProjectDetailClient.tsx` — 삭제 성공/실패 toast 추가, 삭제 버튼 로딩 스피너 개선

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 (`npm run build`)
- [x] lint 에러 없음 (`npm run lint`)
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거