### PR TITLE
release: develop → main (좋아요·댓글 UX 개선 - FRONT-24)

### DIFF
--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { getComments, createComment, type Comment } from '@/lib/api/comments'
+import { useToast } from '@/hooks/useToast'
 import { createClient } from '@/lib/supabase/client'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
@@ -13,6 +15,8 @@ interface CommentSectionProps {
 }
 
 export default function CommentSection({ targetType, targetId }: CommentSectionProps) {
+  const router = useRouter()
+  const { showToast } = useToast()
   const [comments, setComments] = useState<Comment[]>([])
   const [loading, setLoading] = useState(true)
   const [newComment, setNewComment] = useState('')
@@ -52,8 +56,9 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       await createComment(targetType, targetId, { content: newComment.trim() })
       setNewComment('')
       await loadComments()
-    } catch (error: unknown) {
-      console.error('Failed to create comment:', error)
+      showToast('댓글이 등록되었습니다.')
+    } catch {
+      showToast('댓글 등록에 실패했습니다. 다시 시도해주세요.', 'error')
     } finally {
       setSubmitting(false)
     }
@@ -81,15 +86,25 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
           <textarea
             value={newComment}
             onChange={(e) => setNewComment(e.target.value)}
-            placeholder={isAuthenticated ? '댓글을 작성해주세요...' : '로그인 후 댓글을 작성할 수 있습니다.'}
+            placeholder={isAuthenticated ? '댓글을 작성해주세요...' : '댓글을 작성하려면 로그인이 필요합니다.'}
             disabled={!isAuthenticated || submitting}
             rows={3}
             className="w-full resize-none rounded-xl bg-transparent px-4 py-3 text-sm text-gray-800 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:placeholder-gray-500"
           />
           <div className="flex items-center justify-between border-t border-gray-200 px-4 py-2.5 dark:border-gray-700">
-            <span className="text-xs text-gray-400 dark:text-gray-500">
-              {newComment.length > 0 ? `${newComment.length}자` : ''}
-            </span>
+            {!isAuthenticated ? (
+              <button
+                type="button"
+                onClick={() => router.push('/login')}
+                className="text-xs text-blue-500 underline-offset-2 hover:underline dark:text-blue-400"
+              >
+                로그인하러 가기
+              </button>
+            ) : (
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {newComment.length > 0 ? `${newComment.length}자` : ''}
+              </span>
+            )}
             <button
               type="submit"
               disabled={!isAuthenticated || submitting || !newComment.trim()}

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { toggleLike, getLikeStatus } from '@/lib/api/likes'
+import { useToast } from '@/hooks/useToast'
 import { createClient } from '@/lib/supabase/client'
 import type { Session } from '@supabase/supabase-js'
 
@@ -12,6 +14,8 @@ interface LikeButtonProps {
 }
 
 export default function LikeButton({ targetType, targetId, initialLikeCount }: LikeButtonProps) {
+  const router = useRouter()
+  const { showToast } = useToast()
   const [liked, setLiked] = useState(false)
   const [likeCount, setLikeCount] = useState(initialLikeCount)
   const [loading, setLoading] = useState(false)
@@ -31,7 +35,7 @@ export default function LikeButton({ targetType, targetId, initialLikeCount }: L
 
   const handleToggle = async () => {
     if (!isAuthenticated) {
-      alert('좋아요는 로그인 후 이용할 수 있습니다.')
+      showToast('로그인 후 좋아요를 누를 수 있습니다.', 'warning')
       return
     }
     if (loading) return
@@ -47,6 +51,7 @@ export default function LikeButton({ targetType, targetId, initialLikeCount }: L
       // 실패 시 롤백
       setLiked((prev) => !prev)
       setLikeCount((prev) => liked ? prev + 1 : prev - 1)
+      showToast('좋아요 처리에 실패했습니다.', 'error')
     } finally {
       setLoading(false)
     }
@@ -76,7 +81,12 @@ export default function LikeButton({ targetType, targetId, initialLikeCount }: L
         <span>{likeCount.toLocaleString()}</span>
       </button>
       {!isAuthenticated && (
-        <p className="text-xs text-gray-400 dark:text-gray-500">로그인 후 좋아요를 누를 수 있습니다</p>
+        <button
+          onClick={() => router.push('/login')}
+          className="text-xs text-gray-400 underline-offset-2 hover:text-blue-500 hover:underline dark:text-gray-500 dark:hover:text-blue-400"
+        >
+          로그인하고 좋아요 누르기
+        </button>
       )}
     </div>
   )


### PR DESCRIPTION
## 릴리즈

## 포함 PR
- #69 — FRONT-24: refactor: 좋아요·댓글 UX 개선 — 비로그인 로그인 유도 및 피드백 toast 추가

## 변경 내용
- `LikeButton`: `alert()` → warning toast 교체, 비로그인 안내를 `/login` 링크 버튼으로 개선, 좋아요 실패 시 error toast
- `CommentSection`: 댓글 등록 성공/실패 toast 추가, `console.error` 제거, 비로그인 시 `로그인하러 가기` 링크 버튼

## 체크리스트
- [x] develop 빌드 성공
- [x] lint 에러 없음
- [x] PR #69 CI 통과