### PR TITLE
FRONT-29: feat: 블로그 검색 debounce 적용

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -7,6 +7,7 @@ import PostCard from '@/components/PostCard'
 import PostCardSkeleton from '@/components/ui/PostCardSkeleton'
 import Link from 'next/link'
 import { useAuth } from '@/hooks/useAuth'
+import { useDebounce } from '@/hooks/useDebounce'
 
 interface InitialData {
   items: Post[]
@@ -31,10 +32,12 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   const [totalPages, setTotalPages]   = useState(isDefaultUrl ? initialData.totalPages : 1)
   const [loading, setLoading]         = useState(!isDefaultUrl)
   const [searchInput, setSearchInput] = useState(searchFromUrl)
+  const debouncedSearch = useDebounce(searchInput, 400)
   const { isAdmin } = useAuth()
 
   // 최초 마운트 시 SSR 데이터를 그대로 쓰는 경우 fetch 스킵
   const hasMounted = useRef(false)
+  const isFirstDebounce = useRef(true)
 
   const loadPosts = useCallback(async (page: number, search: string, category: string) => {
     try {
@@ -59,6 +62,17 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
     }
     loadPosts(pageFromUrl, searchFromUrl, categoryFromUrl)
   }, [pageFromUrl, searchFromUrl, categoryFromUrl, isDefaultUrl, loadPosts])
+
+  // debounce된 검색어가 바뀌면 URL 업데이트 (최초 마운트 시 스킵)
+  useEffect(() => {
+    if (isFirstDebounce.current) {
+      isFirstDebounce.current = false
+      return
+    }
+    if (debouncedSearch === searchFromUrl) return
+    updateUrl(1, debouncedSearch, categoryFromUrl)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch])
 
   const updateUrl = (page: number, search: string, category: string) => {
     const params = new URLSearchParams()
@@ -130,9 +144,15 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
         <form onSubmit={handleSearch} className="mb-7">
           <div className="flex gap-2">
             <div className="relative flex-1">
-              <svg className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
+              {loading && searchInput ? (
+                <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-blue-500" />
+                </div>
+              ) : (
+                <svg className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              )}
               <input
                 type="text"
                 value={searchInput}
@@ -141,10 +161,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                 className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-blue-500"
               />
             </div>
-            <button type="submit" className="rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100">
-              검색
-            </button>
-            {searchFromUrl && (
+            {(searchInput || searchFromUrl) && (
               <button type="button" onClick={handleClear} className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700">
                 초기화
               </button>

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react'
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+
+  return debouncedValue
+}


### PR DESCRIPTION
## 관련 이슈
closes #81
Jira: FRONT-29

## 변경 유형
- [x] New feature

## 변경 내용
- `useDebounce` 훅 신규 생성 (제네릭, 범용으로 재사용 가능)
- `BlogClient` 검색 입력에 400ms debounce 적용 → 타이핑 멈추면 자동 검색
- 검색 진행 중 입력창 아이콘 → 로딩 스피너로 전환
- 검색 버튼 제거 (debounce로 대체), 초기화 버튼은 입력값 있을 때만 표시
- Enter 키 폼 제출 동작 유지

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거