### PR TITLE
FRONT-31: feat: 프로젝트 목록 검색 기능 추가

### DIFF
--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -7,6 +7,7 @@ import ProjectCard from '@/components/ProjectCard'
 import ProjectCardSkeleton from '@/components/ui/ProjectCardSkeleton'
 import Link from 'next/link'
 import { useAuth } from '@/hooks/useAuth'
+import { useDebounce } from '@/hooks/useDebounce'
 
 const STATUS_FILTERS = [
   { value: 'all',         label: '전체'   },
@@ -29,23 +30,28 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
 
   const pageFromUrl   = Number(searchParams.get('page'))   || 1
   const statusFromUrl = searchParams.get('status') || 'all'
+  const searchFromUrl = searchParams.get('search') || ''
 
-  // SSR initialData는 항상 page=1, status=all 기준으로 받아옴
-  const isDefaultUrl = pageFromUrl === 1 && statusFromUrl === 'all'
+  // SSR initialData는 항상 page=1, status=all, search='' 기준으로 받아옴
+  const isDefaultUrl = pageFromUrl === 1 && statusFromUrl === 'all' && searchFromUrl === ''
 
   const [projects, setProjects]     = useState<Project[]>(isDefaultUrl ? initialData.items : [])
   const [totalPages, setTotalPages] = useState(isDefaultUrl ? initialData.totalPages : 1)
   const [loading, setLoading]       = useState(!isDefaultUrl)
+  const [searchInput, setSearchInput] = useState(searchFromUrl)
+  const debouncedSearch = useDebounce(searchInput, 400)
   const { isAdmin } = useAuth()
 
   // 최초 마운트 시 SSR 데이터를 그대로 쓰는 경우 fetch 스킵
   const hasMounted = useRef(false)
+  const isFirstDebounce = useRef(true)
 
-  const loadProjects = useCallback(async (page: number, status: string) => {
+  const loadProjects = useCallback(async (page: number, status: string, search: string) => {
     try {
       setLoading(true)
       const params: Record<string, unknown> = { page, limit: 9, sortBy: 'created_at', order: 'DESC' }
       if (status !== 'all') params.status = status
+      if (search) params.search = search
       const response = await getProjects(params)
       setProjects(response.items)
       setTotalPages(response.totalPages)
@@ -61,19 +67,32 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
       hasMounted.current = true
       if (isDefaultUrl) return  // 최초 진입, SSR 데이터로 충분
     }
-    loadProjects(pageFromUrl, statusFromUrl)
-  }, [pageFromUrl, statusFromUrl, isDefaultUrl, loadProjects])
+    loadProjects(pageFromUrl, statusFromUrl, searchFromUrl)
+  }, [pageFromUrl, statusFromUrl, searchFromUrl, isDefaultUrl, loadProjects])
 
-  const updateUrl = (page: number, status: string) => {
+  // debounce된 검색어가 바뀌면 URL 업데이트
+  useEffect(() => {
+    if (isFirstDebounce.current) {
+      isFirstDebounce.current = false
+      return
+    }
+    if (debouncedSearch === searchFromUrl) return
+    updateUrl(1, statusFromUrl, debouncedSearch)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch])
+
+  const updateUrl = (page: number, status: string, search: string) => {
     const params = new URLSearchParams()
     if (page > 1)         params.set('page', String(page))
     if (status !== 'all') params.set('status', status)
+    if (search)           params.set('search', search)
     const qs = params.toString()
     router.push(`/projects${qs ? `?${qs}` : ''}`, { scroll: false })
   }
 
-  const handleStatusChange = (status: string) => updateUrl(1, status)
-  const handlePageChange   = (page: number)   => updateUrl(page, statusFromUrl)
+  const handleStatusChange = (status: string) => updateUrl(1, status, searchFromUrl)
+  const handlePageChange   = (page: number)   => updateUrl(page, statusFromUrl, searchFromUrl)
+  const handleClear        = () => { setSearchInput(''); updateUrl(1, statusFromUrl, '') }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -97,6 +116,45 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
           )}
         </div>
 
+        {/* 검색 */}
+        <div className="mb-5">
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              {loading && searchInput ? (
+                <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-blue-500" />
+                </div>
+              ) : (
+                <svg className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              )}
+              <input
+                type="text"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="프로젝트 검색..."
+                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-blue-500"
+              />
+            </div>
+            {(searchInput || searchFromUrl) && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
+              >
+                초기화
+              </button>
+            )}
+          </div>
+          {searchFromUrl && (
+            <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+              <span className="font-semibold text-gray-700 dark:text-gray-300">{'"'}{searchFromUrl}{'"'}</span> 검색 결과
+            </p>
+          )}
+        </div>
+
+        {/* 상태 필터 */}
         <div className="mb-7 flex flex-wrap gap-2">
           {STATUS_FILTERS.map((f) => (
             <button
@@ -121,11 +179,25 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
           </div>
         ) : projects.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-gray-200 py-24 text-center dark:border-gray-700">
-            <p className="text-sm text-gray-400 dark:text-gray-500">프로젝트가 없습니다.</p>
-            {isAdmin && (
+            <p className="text-sm text-gray-400 dark:text-gray-500">
+              {searchFromUrl
+                ? `"${searchFromUrl}"에 대한 결과가 없습니다.`
+                : statusFromUrl !== 'all'
+                  ? '해당 상태의 프로젝트가 없습니다.'
+                  : '프로젝트가 없습니다.'}
+            </p>
+            {isAdmin && !searchFromUrl && statusFromUrl === 'all' && (
               <Link href="/projects/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">
                 첫 프로젝트 작성하기
               </Link>
+            )}
+            {(searchFromUrl || statusFromUrl !== 'all') && (
+              <button
+                onClick={() => { setSearchInput(''); updateUrl(1, 'all', '') }}
+                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400"
+              >
+                전체 목록으로
+              </button>
             )}
           </div>
         ) : (


### PR DESCRIPTION
## 관련 이슈
closes #85
Jira: FRONT-31

## 변경 유형
- [x] New feature

## 변경 내용
- `useDebounce` 훅 재활용하여 400ms debounce 검색 적용
- URL 파라미터 `search` 연동 (status, page와 함께 관리)
- 검색 중 입력창 아이콘 → 로딩 스피너로 전환
- 검색 결과 없을 때 검색어/상태 필터에 맞는 메시지 + 전체 목록으로 버튼
- 초기화 버튼은 입력값 있을 때만 표시
- 블로그 검색과 동일한 UX 패턴으로 일관성 확보

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거