### PR TITLE
FRONT-32: feat: 블로그/프로젝트 목록 정렬 기능 추가

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -24,9 +24,10 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   const pageFromUrl     = Number(searchParams.get('page'))     || 1
   const searchFromUrl   = searchParams.get('search')   || ''
   const categoryFromUrl = searchParams.get('category') || ''
+  const sortFromUrl     = searchParams.get('sort')     || 'latest'
 
-  // SSR initialData는 항상 page=1, 검색/카테고리 없음 기준으로 받아옴
-  const isDefaultUrl = pageFromUrl === 1 && searchFromUrl === '' && categoryFromUrl === ''
+  // SSR initialData는 항상 page=1, 검색/카테고리/정렬 없음 기준으로 받아옴
+  const isDefaultUrl = pageFromUrl === 1 && searchFromUrl === '' && categoryFromUrl === '' && sortFromUrl === 'latest'
 
   const [posts, setPosts]             = useState<Post[]>(isDefaultUrl ? initialData.items : [])
   const [totalPages, setTotalPages]   = useState(isDefaultUrl ? initialData.totalPages : 1)
@@ -39,12 +40,18 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   const hasMounted = useRef(false)
   const isFirstDebounce = useRef(true)
 
-  const loadPosts = useCallback(async (page: number, search: string, category: string) => {
+  const SORT_OPTIONS = [
+    { value: 'latest', label: '최신순' },
+    { value: 'views',  label: '조회수' },
+  ]
+
+  const loadPosts = useCallback(async (page: number, search: string, category: string, sort: string) => {
     try {
       setLoading(true)
-      const params: { page: number; limit: number; search?: string; category?: string } = { page, limit: 10 }
+      const params: Record<string, unknown> = { page, limit: 10 }
       if (search)   params.search   = search
       if (category) params.category = category
+      if (sort === 'views') { params.sortBy = 'view_count'; params.order = 'DESC' }
       const response = await getPosts(params)
       setPosts(response.items)
       setTotalPages(response.totalPages)
@@ -60,8 +67,8 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
       hasMounted.current = true
       if (isDefaultUrl) return  // 최초 진입, SSR 데이터로 충분
     }
-    loadPosts(pageFromUrl, searchFromUrl, categoryFromUrl)
-  }, [pageFromUrl, searchFromUrl, categoryFromUrl, isDefaultUrl, loadPosts])
+    loadPosts(pageFromUrl, searchFromUrl, categoryFromUrl, sortFromUrl)
+  }, [pageFromUrl, searchFromUrl, categoryFromUrl, sortFromUrl, isDefaultUrl, loadPosts])
 
   // debounce된 검색어가 바뀌면 URL 업데이트 (최초 마운트 시 스킵)
   useEffect(() => {
@@ -70,27 +77,28 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
       return
     }
     if (debouncedSearch === searchFromUrl) return
-    updateUrl(1, debouncedSearch, categoryFromUrl)
+    updateUrl(1, debouncedSearch, categoryFromUrl, sortFromUrl)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearch])
 
-  const updateUrl = (page: number, search: string, category: string) => {
+  const updateUrl = (page: number, search: string, category: string, sort: string) => {
     const params = new URLSearchParams()
-    if (page > 1)  params.set('page',     String(page))
-    if (search)    params.set('search',   search)
-    if (category)  params.set('category', category)
+    if (page > 1)          params.set('page',     String(page))
+    if (search)            params.set('search',   search)
+    if (category)          params.set('category', category)
+    if (sort !== 'latest') params.set('sort',     sort)
     const qs = params.toString()
     router.push(`/blog${qs ? `?${qs}` : ''}`, { scroll: false })
   }
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
-    updateUrl(1, searchInput, categoryFromUrl)
+    updateUrl(1, searchInput, categoryFromUrl, sortFromUrl)
   }
 
   const handleClear = () => {
     setSearchInput('')
-    updateUrl(1, '', categoryFromUrl)
+    updateUrl(1, '', categoryFromUrl, sortFromUrl)
   }
 
   const CATEGORIES = [
@@ -129,7 +137,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             <button
               key={value}
               type="button"
-              onClick={() => updateUrl(1, searchFromUrl, value)}
+              onClick={() => updateUrl(1, searchFromUrl, value, sortFromUrl)}
               className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
                 categoryFromUrl === value
                   ? 'bg-blue-600 text-white'
@@ -143,6 +151,15 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
 
         <form onSubmit={handleSearch} className="mb-7">
           <div className="flex gap-2">
+            <select
+              value={sortFromUrl}
+              onChange={(e) => updateUrl(1, searchFromUrl, categoryFromUrl, e.target.value)}
+              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+            >
+              {SORT_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
             <div className="relative flex-1">
               {loading && searchInput ? (
                 <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
@@ -196,7 +213,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             )}
             {(searchFromUrl || categoryFromUrl) && (
               <button
-                onClick={() => { setSearchInput(''); updateUrl(1, '', '') }}
+                onClick={() => { setSearchInput(''); updateUrl(1, '', '', sortFromUrl) }}
                 className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400"
               >
                 전체 목록으로
@@ -216,7 +233,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             {totalPages > 1 && (
               <div className="mt-10 flex items-center justify-center gap-2">
                 <button
-                  onClick={() => updateUrl(Math.max(1, pageFromUrl - 1), searchFromUrl, categoryFromUrl)}
+                  onClick={() => updateUrl(Math.max(1, pageFromUrl - 1), searchFromUrl, categoryFromUrl, sortFromUrl)}
                   disabled={pageFromUrl === 1}
                   className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
                 >
@@ -228,7 +245,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                   {pageFromUrl} / {totalPages}
                 </span>
                 <button
-                  onClick={() => updateUrl(Math.min(totalPages, pageFromUrl + 1), searchFromUrl, categoryFromUrl)}
+                  onClick={() => updateUrl(Math.min(totalPages, pageFromUrl + 1), searchFromUrl, categoryFromUrl, sortFromUrl)}
                   disabled={pageFromUrl === totalPages}
                   className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
                 >

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -31,9 +31,10 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   const pageFromUrl   = Number(searchParams.get('page'))   || 1
   const statusFromUrl = searchParams.get('status') || 'all'
   const searchFromUrl = searchParams.get('search') || ''
+  const sortFromUrl   = searchParams.get('sort')   || 'latest'
 
-  // SSR initialData는 항상 page=1, status=all, search='' 기준으로 받아옴
-  const isDefaultUrl = pageFromUrl === 1 && statusFromUrl === 'all' && searchFromUrl === ''
+  // SSR initialData는 항상 page=1, status=all, search='', sort=latest 기준으로 받아옴
+  const isDefaultUrl = pageFromUrl === 1 && statusFromUrl === 'all' && searchFromUrl === '' && sortFromUrl === 'latest'
 
   const [projects, setProjects]     = useState<Project[]>(isDefaultUrl ? initialData.items : [])
   const [totalPages, setTotalPages] = useState(isDefaultUrl ? initialData.totalPages : 1)
@@ -46,10 +47,22 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   const hasMounted = useRef(false)
   const isFirstDebounce = useRef(true)
 
-  const loadProjects = useCallback(async (page: number, status: string, search: string) => {
+  const SORT_OPTIONS = [
+    { value: 'latest', label: '최신순' },
+    { value: 'views',  label: '조회수' },
+    { value: 'likes',  label: '좋아요' },
+  ]
+
+  const sortToParams = (sort: string): Record<string, string> => {
+    if (sort === 'views') return { sortBy: 'view_count',  order: 'DESC' }
+    if (sort === 'likes') return { sortBy: 'like_count',  order: 'DESC' }
+    return                       { sortBy: 'created_at', order: 'DESC' }
+  }
+
+  const loadProjects = useCallback(async (page: number, status: string, search: string, sort: string) => {
     try {
       setLoading(true)
-      const params: Record<string, unknown> = { page, limit: 9, sortBy: 'created_at', order: 'DESC' }
+      const params: Record<string, unknown> = { page, limit: 9, ...sortToParams(sort) }
       if (status !== 'all') params.status = status
       if (search) params.search = search
       const response = await getProjects(params)
@@ -67,8 +80,8 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
       hasMounted.current = true
       if (isDefaultUrl) return  // 최초 진입, SSR 데이터로 충분
     }
-    loadProjects(pageFromUrl, statusFromUrl, searchFromUrl)
-  }, [pageFromUrl, statusFromUrl, searchFromUrl, isDefaultUrl, loadProjects])
+    loadProjects(pageFromUrl, statusFromUrl, searchFromUrl, sortFromUrl)
+  }, [pageFromUrl, statusFromUrl, searchFromUrl, sortFromUrl, isDefaultUrl, loadProjects])
 
   // debounce된 검색어가 바뀌면 URL 업데이트
   useEffect(() => {
@@ -77,22 +90,23 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
       return
     }
     if (debouncedSearch === searchFromUrl) return
-    updateUrl(1, statusFromUrl, debouncedSearch)
+    updateUrl(1, statusFromUrl, debouncedSearch, sortFromUrl)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearch])
 
-  const updateUrl = (page: number, status: string, search: string) => {
+  const updateUrl = (page: number, status: string, search: string, sort: string) => {
     const params = new URLSearchParams()
-    if (page > 1)         params.set('page', String(page))
-    if (status !== 'all') params.set('status', status)
-    if (search)           params.set('search', search)
+    if (page > 1)          params.set('page',   String(page))
+    if (status !== 'all')  params.set('status', status)
+    if (search)            params.set('search', search)
+    if (sort !== 'latest') params.set('sort',   sort)
     const qs = params.toString()
     router.push(`/projects${qs ? `?${qs}` : ''}`, { scroll: false })
   }
 
-  const handleStatusChange = (status: string) => updateUrl(1, status, searchFromUrl)
-  const handlePageChange   = (page: number)   => updateUrl(page, statusFromUrl, searchFromUrl)
-  const handleClear        = () => { setSearchInput(''); updateUrl(1, statusFromUrl, '') }
+  const handleStatusChange = (status: string) => updateUrl(1, status, searchFromUrl, sortFromUrl)
+  const handlePageChange   = (page: number)   => updateUrl(page, statusFromUrl, searchFromUrl, sortFromUrl)
+  const handleClear        = () => { setSearchInput(''); updateUrl(1, statusFromUrl, '', sortFromUrl) }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -119,6 +133,15 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
         {/* 검색 */}
         <div className="mb-5">
           <div className="flex gap-2">
+            <select
+              value={sortFromUrl}
+              onChange={(e) => updateUrl(1, statusFromUrl, searchFromUrl, e.target.value)}
+              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+            >
+              {SORT_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
             <div className="relative flex-1">
               {loading && searchInput ? (
                 <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
@@ -193,7 +216,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
             )}
             {(searchFromUrl || statusFromUrl !== 'all') && (
               <button
-                onClick={() => { setSearchInput(''); updateUrl(1, 'all', '') }}
+                onClick={() => { setSearchInput(''); updateUrl(1, 'all', '', sortFromUrl) }}
                 className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400"
               >
                 전체 목록으로


### PR DESCRIPTION
## 관련 이슈
closes #87
Jira: FRONT-32

## 변경 유형
- [x] New feature

## 변경 내용
- `BlogClient`: 최신순 / 조회수순 정렬 select 추가
- `ProjectsClient`: 최신순 / 조회수순 / 좋아요순 정렬 select 추가
- URL 파라미터 `sort` 연동 (기본값 `latest`는 URL에 미포함으로 URL 간결 유지)
- 정렬 변경 시 page=1 리셋
- 검색 · 상태필터 · 정렬 파라미터 모두 함께 유지 (상호 독립)

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거