### PR TITLE
FRONT-34: fix: 프로젝트 썸네일 잘림 문제 수정

### DIFF
--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -183,13 +183,14 @@ export default function ProjectDetailClient({ project, from }: Props) {
       <main className="mx-auto max-w-[1000px] px-5 py-10">
         <div className="space-y-8">
           {project.thumbnailUrl && (
-            <div className="relative aspect-video overflow-hidden rounded-2xl shadow-md">
+            <div className="relative overflow-hidden rounded-2xl bg-gray-100 shadow-md dark:bg-gray-800">
               <Image
                 src={project.thumbnailUrl}
                 alt={project.title}
-                fill
+                width={1000}
+                height={600}
                 sizes="(max-width: 1000px) 100vw, 1000px"
-                className="object-cover"
+                className="h-auto w-full object-contain"
               />
             </div>
           )}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -25,14 +25,14 @@ export default function ProjectCard({ project }: ProjectCardProps) {
     <div className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
 
       {/* 썸네일 */}
-      <div className="relative aspect-video w-full overflow-hidden">
+      <div className="relative aspect-video w-full overflow-hidden bg-gray-100 dark:bg-gray-700">
         {project.thumbnailUrl ? (
           <Image
             src={project.thumbnailUrl}
             alt={project.title}
             fill
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            className="object-contain"
           />
         ) : (
           /* 플레이스홀더: 그라디언트 배경 + devicon 아이콘 */


### PR DESCRIPTION
## 관련 이슈
closes #91
Jira: FRONT-34

## 변경 유형
- [x] Bug fix

## 변경 내용
- **상세 페이지**: `fill + object-cover` → `width/height + object-contain`으로 교체
  - 썸네일이 aspect-video에 맞게 크롭되던 문제 해결
  - `bg-gray-100 dark:bg-gray-800` 배경으로 레터박스 처리
- **카드**: `object-cover` → `object-contain + bg-gray` 배경으로 교체
  - 그리드 높이 통일은 `aspect-video` 유지, 이미지는 잘리지 않게 변경

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거