### PR TITLE
FRONT-33: fix: 모바일 프로젝트·블로그 상세 가독성 개선

### DIFF
--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -56,6 +56,11 @@ export default function BlogPostClient({ post, from }: Props) {
   const markdownComponents: Components = useMemo(() => ({
     h2: ({ children }) => <h2 id={slugify(String(children))}>{children}</h2>,
     h3: ({ children }) => <h3 id={slugify(String(children))}>{children}</h3>,
+    table: ({ children }) => (
+      <div className="overflow-x-auto">
+        <table>{children}</table>
+      </div>
+    ),
   }), [])
 
   useEffect(() => {

--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -308,7 +308,7 @@ export default function BlogPostClient({ post, from }: Props) {
             </div>
           )}
 
-          <section className="rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-6 sm:py-10 md:px-10 md:py-12">
+          <section className="-mx-4 bg-white px-4 py-6 dark:bg-gray-800 sm:mx-0 sm:rounded-2xl sm:border sm:border-gray-200 sm:px-6 sm:py-10 sm:shadow-sm dark:sm:border-gray-700 md:px-10 md:py-12">
             <div className="markdown-body">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}

--- a/app/globals.css
+++ b/app/globals.css
@@ -169,7 +169,7 @@ body {
 /* 리스트 */
 .markdown-body ul,
 .markdown-body ol {
-  padding-left: 1.5em;
+  padding-left: 1.75em;
   margin: 1em 0;
 }
 
@@ -182,13 +182,13 @@ body {
 }
 
 .markdown-body li {
-  margin: 0.35em 0;
-  line-height: 1.7;
+  margin: 0.45em 0;
+  line-height: 1.75;
 }
 
 .markdown-body li > ul,
 .markdown-body li > ol {
-  margin: 0.25em 0;
+  margin: 0.3em 0;
 }
 
 /* 체크박스 리스트 (GFM) */
@@ -208,12 +208,7 @@ body {
   border-top-color: #374151;
 }
 
-/* 표 (GFM) — 모바일: 가로 스크롤 래퍼 */
-.markdown-body .table-wrapper {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
+/* 표 (GFM) — 가로 스크롤은 ReactMarkdown 커스텀 컴포넌트로 처리 */
 .markdown-body table {
   width: 100%;
   border-collapse: collapse;

--- a/app/globals.css
+++ b/app/globals.css
@@ -191,6 +191,14 @@ body {
   margin: 0.3em 0;
 }
 
+/* 중첩 리스트: 레벨이 깊어질수록 들여쓰기 줄임 */
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ul,
+.markdown-body ol ol {
+  padding-left: 1.1em;
+}
+
 /* 체크박스 리스트 (GFM) */
 .markdown-body input[type="checkbox"] {
   margin-right: 0.5em;

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -226,7 +226,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
             </section>
           )}
 
-          <section className="rounded-2xl bg-white px-4 py-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:px-8 sm:py-8">
+          <section className="-mx-5 bg-white px-5 py-6 dark:bg-gray-800 sm:mx-0 sm:rounded-2xl sm:px-8 sm:py-8 sm:shadow-sm sm:ring-1 sm:ring-gray-200 dark:sm:ring-gray-700">
             <h2 className="mb-5 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">📋 Description</h2>
             <div className="markdown-body">
               <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>{project.description}</ReactMarkdown>

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { type Project } from '@/lib/api/projects'
 import { useAuth } from '@/hooks/useAuth'
 import LikeButton from '@/components/LikeButton'
 import CommentSection from '@/components/CommentSection'
 import ReactMarkdown from 'react-markdown'
+import type { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import { formatDistanceToNow } from 'date-fns'
@@ -64,6 +65,14 @@ export default function ProjectDetailClient({ project, from }: Props) {
   }
 
   const status = statusConfig[project.status as keyof typeof statusConfig] ?? statusConfig.archived
+
+  const markdownComponents: Components = useMemo(() => ({
+    table: ({ children }) => (
+      <div className="overflow-x-auto">
+        <table>{children}</table>
+      </div>
+    ),
+  }), [])
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -217,10 +226,10 @@ export default function ProjectDetailClient({ project, from }: Props) {
             </section>
           )}
 
-          <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:p-8">
+          <section className="rounded-2xl bg-white px-4 py-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:px-8 sm:py-8">
             <h2 className="mb-5 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">📋 Description</h2>
             <div className="markdown-body">
-              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{project.description}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>{project.description}</ReactMarkdown>
             </div>
           </section>
 


### PR DESCRIPTION
## 관련 이슈
closes #90
Jira: FRONT-33

## 변경 유형
- [x] Bug fix

## 변경 내용
- **테이블 가로 스크롤**: ReactMarkdown `table` 커스텀 컴포넌트로 `overflow-x: auto` 래퍼 추가
  - 프로젝트 상세(`ProjectDetailClient`) + 블로그 상세(`BlogPostClient`) 모두 적용
  - 기존 `.table-wrapper` CSS는 동작하지 않던 dead code → 제거
- **프로젝트 설명 섹션 패딩**: 모바일 `p-6` → `px-4 py-6` (좌우 여백 확보)
- **리스트 가독성**: `padding-left` 1.5em → 1.75em, `line-height` 1.7 → 1.75, 항목 간격 소폭 증가

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거