### PR TITLE
FRONT-33: fix: 모바일 프로젝트·블로그 상세 가독성 개선

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,7 +37,7 @@ body {
    @tailwindcss/typography 호환성 이슈 우회
 ───────────────────────────────────────────── */
 .markdown-body {
-  font-size: 0.9375rem; /* 15px — 모바일 기본값 */
+  font-size: 0.875rem; /* 14px — 모바일 기본값 */
   line-height: 1.8;
   color: #374151;
   word-break: break-word;
@@ -296,7 +296,7 @@ body {
 ───────────────────────────────────────────── */
 @media (min-width: 640px) {
   .markdown-body {
-    font-size: 1rem;
+    font-size: 0.9375rem; /* 15px */
   }
 
   .markdown-body h1 { font-size: 1.875rem; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -191,12 +191,20 @@ body {
   margin: 0.3em 0;
 }
 
-/* 중첩 리스트: 레벨이 깊어질수록 들여쓰기 줄임 */
+/* 중첩 리스트: 들여쓰기 최소화 + 불릿 모양으로 계층 구분 */
 .markdown-body ul ul,
 .markdown-body ul ol,
 .markdown-body ol ul,
 .markdown-body ol ol {
-  padding-left: 1.1em;
+  padding-left: 0.75em;
+}
+
+.markdown-body ul ul {
+  list-style-type: circle;
+}
+
+.markdown-body ul ul ul {
+  list-style-type: square;
 }
 
 /* 체크박스 리스트 (GFM) */


### PR DESCRIPTION
## 관련 이슈
closes #90
Jira: FRONT-33

## 변경 유형
- [x] Bug fix

## 변경 내용
- **테이블 가로 스크롤**: ReactMarkdown `table` 커스텀 컴포넌트로 `overflow-x: auto` 래퍼 추가 (프로젝트·블로그 상세 모두 적용)
- **본문 섹션 풀블리드**: 모바일에서 `-mx` 네거티브 마진으로 Description 섹션을 화면 가장자리까지 확장, sm+ 에서는 카드 스타일 유지
- **중첩 리스트 개선**: 2단계 이상 `padding-left` 0.75em, `disc → circle → square` 불릿 스타일로 계층 구분
- **폰트 크기 조정**: 모바일 15px → 14px, 데스크탑 16px → 15px (em 기반 여백도 비례 축소)

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거