### PR TITLE
FRONT-36: refactor: 에디터 폼 UI/UX 개선

### DIFF
--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -142,6 +142,9 @@ export default function EditPostPage() {
         {!preview ? (
           <form id="edit-post-form" onSubmit={handleSubmit}>
             <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+
+              {/* 기본 정보 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기본 정보</p>
               <FormField label="제목" required>
                 <input
                   type="text"
@@ -151,22 +154,16 @@ export default function EditPostPage() {
                   className={`${inputClass} font-semibold`}
                 />
               </FormField>
-              <FormField label="요약" required>
+              <FormField label="한 줄 요약" required>
                 <input
                   type="text"
                   value={formData.summary}
                   onChange={(e) => setFormData({ ...formData, summary: e.target.value })}
-                  placeholder="한 줄 소개"
+                  placeholder="목록/카드에 표시될 한 줄 소개"
                   className={inputClass}
                 />
               </FormField>
-              <FormField label="썸네일 이미지">
-                <ThumbnailUploader
-                  value={formData.thumbnailUrl}
-                  onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
-                />
-              </FormField>
-              <div className="mb-5 grid gap-5 sm:grid-cols-2">
+              <div className="grid gap-5 sm:grid-cols-2">
                 <FormField label="카테고리" required>
                   <select
                     value={formData.category}
@@ -186,7 +183,18 @@ export default function EditPostPage() {
                   />
                 </FormField>
               </div>
-              <FormField label="본문 (Markdown)" required>
+              <FormField label="썸네일 이미지">
+                <ThumbnailUploader
+                  value={formData.thumbnailUrl}
+                  onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
+                />
+              </FormField>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 본문 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">본문 (Markdown)</p>
+              <FormField label="본문" required>
                 <textarea
                   value={formData.content}
                   rows={28}

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -118,6 +118,9 @@ export default function NewPostPage() {
         {!preview ? (
           <form id="new-post-form" onSubmit={handleSubmit}>
             <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+
+              {/* 기본 정보 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기본 정보</p>
               <FormField label="제목" required>
                 <input
                   type="text"
@@ -127,22 +130,16 @@ export default function NewPostPage() {
                   className={`${inputClass} font-semibold`}
                 />
               </FormField>
-              <FormField label="요약" required>
+              <FormField label="한 줄 요약" required>
                 <input
                   type="text"
                   value={formData.summary}
                   onChange={(e) => setFormData({ ...formData, summary: e.target.value })}
-                  placeholder="한 줄 소개"
+                  placeholder="목록/카드에 표시될 한 줄 소개"
                   className={inputClass}
                 />
               </FormField>
-              <FormField label="썸네일 이미지">
-                <ThumbnailUploader
-                  value={formData.thumbnailUrl}
-                  onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
-                />
-              </FormField>
-              <div className="mb-5 grid gap-5 sm:grid-cols-2">
+              <div className="grid gap-5 sm:grid-cols-2">
                 <FormField label="카테고리" required>
                   <select
                     value={formData.category}
@@ -162,7 +159,18 @@ export default function NewPostPage() {
                   />
                 </FormField>
               </div>
-              <FormField label="본문 (Markdown)" required>
+              <FormField label="썸네일 이미지">
+                <ThumbnailUploader
+                  value={formData.thumbnailUrl}
+                  onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
+                />
+              </FormField>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 본문 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">본문 (Markdown)</p>
+              <FormField label="본문" required>
                 <textarea
                   value={formData.content}
                   rows={28}

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -15,6 +15,15 @@ import EditorBar from '@/components/EditorBar'
 import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeHighlight from 'rehype-highlight'
+
+const STATUS_CONFIG = {
+  'in-progress': { label: '진행중', className: 'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-400 dark:ring-blue-500/30' },
+  completed:     { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
+  archived:      { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
+}
 
 export default function EditProjectPage() {
   const params = useParams()
@@ -24,6 +33,7 @@ export default function EditProjectPage() {
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const [preview, setPreview] = useState(false)
   const [showCancelConfirm, setShowCancelConfirm] = useState(false)
 
   const [formData, setFormData] = useState({
@@ -44,11 +54,9 @@ export default function EditProjectPage() {
 
   useEffect(() => {
     if (!authReady) return
-    if (!isAdmin) {
-      router.replace('/projects')
-      return
-    }
+    if (!isAdmin) { router.replace('/projects'); return }
     if (params.id) loadProject(params.id as string)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params.id, isAdmin, authReady])
 
   const loadProject = async (id: string) => {
@@ -99,7 +107,6 @@ export default function EditProjectPage() {
       if (formData.demoUrl) payload.demoUrl = formData.demoUrl
       if (formData.githubUrl) payload.githubUrl = formData.githubUrl
       if (formData.tags.length > 0) payload.tags = formData.tags
-
       await api.patch(`/projects/${params.id}`, payload)
       showToast('프로젝트가 수정되었습니다.')
       router.replace(`/projects/${params.id}`)
@@ -112,10 +119,7 @@ export default function EditProjectPage() {
   }
 
   const handleCancel = () => {
-    if (hasChanges) {
-      setShowCancelConfirm(true)
-      return
-    }
+    if (hasChanges) { setShowCancelConfirm(true); return }
     router.push(`/projects/${params.id}`)
   }
 
@@ -141,91 +145,147 @@ export default function EditProjectPage() {
         submitting={submitting}
         onCancel={handleCancel}
         formId="edit-project-form"
+        preview={preview}
+        onPreviewChange={setPreview}
       />
 
       <main className="mx-auto max-w-[1000px] px-5 py-8">
         {error && <ErrorAlert message={error} />}
 
-        <form id="edit-project-form" onSubmit={handleSubmit}>
-          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
-            <FormField label="제목" required>
-              <input
-                type="text"
-                value={formData.title}
-                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                placeholder="프로젝트 제목"
-                className={`${inputClass} font-semibold`}
-              />
-            </FormField>
-            <FormField label="요약" required>
-              <input
-                type="text"
-                value={formData.summary}
-                onChange={(e) => setFormData({ ...formData, summary: e.target.value })}
-                placeholder="한 줄 소개"
-                className={inputClass}
-              />
-            </FormField>
-            <FormField label="상세 설명" required>
-              <textarea
-                value={formData.description}
-                rows={10}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="프로젝트 상세 설명"
-                className={inputClass}
-              />
-            </FormField>
-            <FormField label="기술 스택" required>
-              <TechStackInput
-                value={formData.techStack}
-                onChange={(v) => setFormData({ ...formData, techStack: v })}
-              />
-            </FormField>
-            <FormField label="태그">
-              <TechStackInput
-                value={formData.tags}
-                onChange={(v) => setFormData({ ...formData, tags: v })}
-              />
-            </FormField>
-            <div className="grid gap-5 sm:grid-cols-2">
-              <FormField label="썸네일 이미지">
-                <ThumbnailUploader
-                  value={formData.thumbnailUrl}
-                  onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
-                />
-              </FormField>
-              <FormField label="상태">
-                <select
-                  value={formData.status}
-                  onChange={(e) => setFormData({ ...formData, status: e.target.value as 'in-progress' | 'completed' | 'archived' })}
-                  className={inputClass}
-                >
-                  <option value="in-progress">진행중</option>
-                  <option value="completed">완료</option>
-                  <option value="archived">보관</option>
-                </select>
-              </FormField>
-              <FormField label="데모 URL">
+        {!preview ? (
+          <form id="edit-project-form" onSubmit={handleSubmit}>
+            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+
+              {/* 기본 정보 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기본 정보</p>
+              <FormField label="제목" required>
                 <input
-                  type="url"
-                  value={formData.demoUrl}
-                  onChange={(e) => setFormData({ ...formData, demoUrl: e.target.value })}
-                  placeholder="https://demo.example.com"
-                  className={inputClass}
+                  type="text"
+                  value={formData.title}
+                  onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                  placeholder="프로젝트 제목"
+                  className={`${inputClass} font-semibold`}
                 />
               </FormField>
-              <FormField label="GitHub URL">
+              <FormField label="한 줄 요약" required>
                 <input
-                  type="url"
-                  value={formData.githubUrl}
-                  onChange={(e) => setFormData({ ...formData, githubUrl: e.target.value })}
-                  placeholder="https://github.com/username/repo"
+                  type="text"
+                  value={formData.summary}
+                  onChange={(e) => setFormData({ ...formData, summary: e.target.value })}
+                  placeholder="목록/카드에 표시될 한 줄 소개"
                   className={inputClass}
                 />
               </FormField>
+              <div className="grid gap-5 sm:grid-cols-2">
+                <FormField label="상태">
+                  <select
+                    value={formData.status}
+                    onChange={(e) => setFormData({ ...formData, status: e.target.value as 'in-progress' | 'completed' | 'archived' })}
+                    className={inputClass}
+                  >
+                    <option value="in-progress">진행중</option>
+                    <option value="completed">완료</option>
+                    <option value="archived">보관</option>
+                  </select>
+                </FormField>
+                <FormField label="썸네일 이미지">
+                  <ThumbnailUploader
+                    value={formData.thumbnailUrl}
+                    onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
+                  />
+                </FormField>
+              </div>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 상세 설명 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">상세 설명 (Markdown)</p>
+              <FormField label="프로젝트 설명" required>
+                <textarea
+                  value={formData.description}
+                  rows={20}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder={`## 프로젝트 개요\n\n이 프로젝트는...\n\n## 주요 기능\n\n- 기능 1\n- 기능 2\n\n## 기술적 도전\n\n\`\`\`javascript\nconst example = 'code';\n\`\`\``}
+                  className={`${inputClass} font-mono text-sm leading-relaxed`}
+                />
+                <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+                  Markdown 문법을 지원합니다. 미리보기 탭에서 렌더링을 확인하세요.
+                </p>
+              </FormField>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 기술 & 태그 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기술 & 태그</p>
+              <FormField label="기술 스택" required>
+                <TechStackInput
+                  value={formData.techStack}
+                  onChange={(v) => setFormData({ ...formData, techStack: v })}
+                />
+              </FormField>
+              <FormField label="태그">
+                <TechStackInput
+                  value={formData.tags}
+                  onChange={(v) => setFormData({ ...formData, tags: v })}
+                />
+              </FormField>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 링크 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">링크</p>
+              <div className="grid gap-5 sm:grid-cols-2">
+                <FormField label="데모 URL">
+                  <input
+                    type="url"
+                    value={formData.demoUrl}
+                    onChange={(e) => setFormData({ ...formData, demoUrl: e.target.value })}
+                    placeholder="https://demo.example.com"
+                    className={inputClass}
+                  />
+                </FormField>
+                <FormField label="GitHub URL">
+                  <input
+                    type="url"
+                    value={formData.githubUrl}
+                    onChange={(e) => setFormData({ ...formData, githubUrl: e.target.value })}
+                    placeholder="https://github.com/username/repo"
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+
+            </div>
+          </form>
+        ) : (
+          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800 sm:p-12">
+            <div className="mb-4">
+              <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ${STATUS_CONFIG[formData.status].className}`}>
+                {STATUS_CONFIG[formData.status].label}
+              </span>
+            </div>
+            <h1 className="mb-3 text-3xl font-bold text-gray-900 dark:text-white">
+              {formData.title || '제목 없음'}
+            </h1>
+            <p className="mb-6 text-lg text-gray-500 dark:text-gray-400">
+              {formData.summary || '요약 없음'}
+            </p>
+            {formData.techStack.length > 0 && (
+              <div className="mb-6 flex flex-wrap gap-2">
+                {formData.techStack.map((tech) => (
+                  <span key={tech} className="rounded-lg bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30">
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="markdown-body">
+              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                {formData.description || '*내용 없음*'}
+              </ReactMarkdown>
             </div>
           </div>
-        </form>
+        )}
       </main>
     </div>
   )

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -14,6 +14,15 @@ import EditorBar from '@/components/EditorBar'
 import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { inputClass } from '@/lib/styles/form'
 import api from '@/lib/api/client'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeHighlight from 'rehype-highlight'
+
+const STATUS_CONFIG = {
+  'in-progress': { label: '진행중', className: 'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-400 dark:ring-blue-500/30' },
+  completed:     { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
+  archived:      { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
+}
 
 const EMPTY_FORM = {
   title: '',
@@ -33,6 +42,7 @@ export default function NewProjectPage() {
   const { showToast } = useToast()
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const [preview, setPreview] = useState(false)
   const [formData, setFormData] = useState(EMPTY_FORM)
   const [showCancelConfirm, setShowCancelConfirm] = useState(false)
 
@@ -79,10 +89,7 @@ export default function NewProjectPage() {
   }
 
   const handleCancel = () => {
-    if (hasChanges) {
-      setShowCancelConfirm(true)
-      return
-    }
+    if (hasChanges) { setShowCancelConfirm(true); return }
     router.back()
   }
 
@@ -108,91 +115,147 @@ export default function NewProjectPage() {
         onCancel={handleCancel}
         formId="project-form"
         submitLabel="작성하기"
+        preview={preview}
+        onPreviewChange={setPreview}
       />
 
       <main className="mx-auto max-w-[1000px] px-5 py-8">
         {error && <ErrorAlert message={error} />}
 
-        <form id="project-form" onSubmit={handleSubmit}>
-          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
-            <FormField label="제목" required>
-              <input
-                type="text"
-                value={formData.title}
-                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                placeholder="프로젝트 제목"
-                className={`${inputClass} font-semibold`}
-              />
-            </FormField>
-            <FormField label="요약" required>
-              <input
-                type="text"
-                value={formData.summary}
-                onChange={(e) => setFormData({ ...formData, summary: e.target.value })}
-                placeholder="한 줄 소개"
-                className={inputClass}
-              />
-            </FormField>
-            <FormField label="상세 설명" required>
-              <textarea
-                value={formData.description}
-                rows={10}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="프로젝트 상세 설명"
-                className={inputClass}
-              />
-            </FormField>
-            <FormField label="기술 스택" required>
-              <TechStackInput
-                value={formData.techStack}
-                onChange={(v) => setFormData({ ...formData, techStack: v })}
-              />
-            </FormField>
-            <FormField label="태그">
-              <TechStackInput
-                value={formData.tags}
-                onChange={(v) => setFormData({ ...formData, tags: v })}
-              />
-            </FormField>
-            <div className="grid gap-5 sm:grid-cols-2">
-              <FormField label="썸네일 이미지">
-                <ThumbnailUploader
-                  value={formData.thumbnailUrl}
-                  onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
-                />
-              </FormField>
-              <FormField label="상태">
-                <select
-                  value={formData.status}
-                  onChange={(e) => setFormData({ ...formData, status: e.target.value as 'in-progress' | 'completed' | 'archived' })}
-                  className={inputClass}
-                >
-                  <option value="in-progress">진행중</option>
-                  <option value="completed">완료</option>
-                  <option value="archived">보관</option>
-                </select>
-              </FormField>
-              <FormField label="데모 URL">
+        {!preview ? (
+          <form id="project-form" onSubmit={handleSubmit}>
+            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+
+              {/* 기본 정보 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기본 정보</p>
+              <FormField label="제목" required>
                 <input
-                  type="url"
-                  value={formData.demoUrl}
-                  onChange={(e) => setFormData({ ...formData, demoUrl: e.target.value })}
-                  placeholder="https://demo.example.com"
-                  className={inputClass}
+                  type="text"
+                  value={formData.title}
+                  onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                  placeholder="프로젝트 제목"
+                  className={`${inputClass} font-semibold`}
                 />
               </FormField>
-              <FormField label="GitHub URL">
+              <FormField label="한 줄 요약" required>
                 <input
-                  type="url"
-                  value={formData.githubUrl}
-                  onChange={(e) => setFormData({ ...formData, githubUrl: e.target.value })}
-                  placeholder="https://github.com/username/repo"
+                  type="text"
+                  value={formData.summary}
+                  onChange={(e) => setFormData({ ...formData, summary: e.target.value })}
+                  placeholder="목록/카드에 표시될 한 줄 소개"
                   className={inputClass}
                 />
               </FormField>
+              <div className="grid gap-5 sm:grid-cols-2">
+                <FormField label="상태">
+                  <select
+                    value={formData.status}
+                    onChange={(e) => setFormData({ ...formData, status: e.target.value as 'in-progress' | 'completed' | 'archived' })}
+                    className={inputClass}
+                  >
+                    <option value="in-progress">진행중</option>
+                    <option value="completed">완료</option>
+                    <option value="archived">보관</option>
+                  </select>
+                </FormField>
+                <FormField label="썸네일 이미지">
+                  <ThumbnailUploader
+                    value={formData.thumbnailUrl}
+                    onChange={(url) => setFormData({ ...formData, thumbnailUrl: url })}
+                  />
+                </FormField>
+              </div>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 상세 설명 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">상세 설명 (Markdown)</p>
+              <FormField label="프로젝트 설명" required>
+                <textarea
+                  value={formData.description}
+                  rows={20}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder={`## 프로젝트 개요\n\n이 프로젝트는...\n\n## 주요 기능\n\n- 기능 1\n- 기능 2\n\n## 기술적 도전\n\n\`\`\`javascript\nconst example = 'code';\n\`\`\``}
+                  className={`${inputClass} font-mono text-sm leading-relaxed`}
+                />
+                <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+                  Markdown 문법을 지원합니다. 미리보기 탭에서 렌더링을 확인하세요.
+                </p>
+              </FormField>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 기술 & 태그 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기술 & 태그</p>
+              <FormField label="기술 스택" required>
+                <TechStackInput
+                  value={formData.techStack}
+                  onChange={(v) => setFormData({ ...formData, techStack: v })}
+                />
+              </FormField>
+              <FormField label="태그">
+                <TechStackInput
+                  value={formData.tags}
+                  onChange={(v) => setFormData({ ...formData, tags: v })}
+                />
+              </FormField>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 링크 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">링크</p>
+              <div className="grid gap-5 sm:grid-cols-2">
+                <FormField label="데모 URL">
+                  <input
+                    type="url"
+                    value={formData.demoUrl}
+                    onChange={(e) => setFormData({ ...formData, demoUrl: e.target.value })}
+                    placeholder="https://demo.example.com"
+                    className={inputClass}
+                  />
+                </FormField>
+                <FormField label="GitHub URL">
+                  <input
+                    type="url"
+                    value={formData.githubUrl}
+                    onChange={(e) => setFormData({ ...formData, githubUrl: e.target.value })}
+                    placeholder="https://github.com/username/repo"
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+
+            </div>
+          </form>
+        ) : (
+          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800 sm:p-12">
+            <div className="mb-4">
+              <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ${STATUS_CONFIG[formData.status].className}`}>
+                {STATUS_CONFIG[formData.status].label}
+              </span>
+            </div>
+            <h1 className="mb-3 text-3xl font-bold text-gray-900 dark:text-white">
+              {formData.title || '제목 없음'}
+            </h1>
+            <p className="mb-6 text-lg text-gray-500 dark:text-gray-400">
+              {formData.summary || '요약 없음'}
+            </p>
+            {formData.techStack.length > 0 && (
+              <div className="mb-6 flex flex-wrap gap-2">
+                {formData.techStack.map((tech) => (
+                  <span key={tech} className="rounded-lg bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30">
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="markdown-body">
+              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                {formData.description || '*내용 없음*'}
+              </ReactMarkdown>
             </div>
           </div>
-        </form>
+        )}
       </main>
     </div>
   )


### PR DESCRIPTION
## 관련 이슈
closes #99
Jira: FRONT-36

## 변경 유형
- [x] Refactor

## 변경 내용
- 블로그/프로젝트 에디터 4개 페이지(new/edit) 폼 구조 통일
- 기본 정보 / 본문(Markdown) 섹션 구분선 및 레이블 추가
- 프로젝트 편집 페이지에 미리보기 토글 추가 (blog와 동일)
- "요약" → "한 줄 요약" rename, placeholder "목록/카드에 표시될 한 줄 소개"로 개선
- 썸네일을 카테고리/상태+태그 그리드 아래로 이동
- 프로젝트 에디터에 상세 설명 / 기술 & 태그 / 링크 섹션 구분 추가

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거