### PR TITLE
fix: comments API 페이지네이션 응답 처리

### DIFF
--- a/lib/api/comments.ts
+++ b/lib/api/comments.ts
@@ -27,8 +27,8 @@ export async function getComments(
   targetType: CommentTargetType,
   targetId: string
 ): Promise<Comment[]> {
-  const response = await api.get<Comment[]>(`/comments/${targetType}/${targetId}`)
-  return response.data
+  const response = await api.get<{ items: Comment[] }>(`/comments/${targetType}/${targetId}`)
+  return response.data.items
 }
 
 /**


### PR DESCRIPTION
## 문제
백엔드 BACK-2 작업으로 `GET /comments/:type/:id` 응답이 `Comment[]` 배열에서 `{ items, total, ... }` 객체로 변경됨.
프론트엔드에서 `comments.map()` 호출 시 `y.map is not a function` 에러 발생.

## 수정
`getComments()` 에서 `response.data` → `response.data.items` 로 변경