### PR TITLE
FRONT-35: feat: 프로젝트 이미지 갤러리 기능 추가

### DIFF
--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -204,6 +204,30 @@ export default function ProjectDetailClient({ project, from }: Props) {
             </div>
           )}
 
+          {project.imageUrls && project.imageUrls.length > 0 && (
+            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700">
+              <h2 className="mb-4 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">🖼 Gallery</h2>
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {project.imageUrls.map((url, idx) => (
+                  <a key={url} href={url} target="_blank" rel="noopener noreferrer" className="group relative aspect-video overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-700">
+                    <Image
+                      src={url}
+                      alt={`${project.title} 이미지 ${idx + 1}`}
+                      fill
+                      sizes="(max-width: 640px) 50vw, 33vw"
+                      className="object-cover transition-transform duration-300 group-hover:scale-105"
+                    />
+                    <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all group-hover:bg-black/30 group-hover:opacity-100">
+                      <svg className="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7" />
+                      </svg>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+
           {project.techStack?.length > 0 && (
             <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700">
               <h2 className="mb-4 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">🛠 Tech Stack</h2>

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -8,6 +8,7 @@ import { useToast } from '@/hooks/useToast'
 import { getProject } from '@/lib/api/projects'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
+import ImageGalleryUploader from '@/components/ImageGalleryUploader'
 import FormField from '@/components/ui/FormField'
 import ErrorAlert from '@/components/ui/ErrorAlert'
 import Spinner from '@/components/ui/Spinner'
@@ -41,6 +42,7 @@ export default function EditProjectPage() {
     summary: '',
     description: '',
     thumbnailUrl: '',
+    imageUrls: [] as string[],
     demoUrl: '',
     githubUrl: '',
     techStack: [] as string[],
@@ -68,6 +70,7 @@ export default function EditProjectPage() {
         summary: project.summary,
         description: project.description,
         thumbnailUrl: project.thumbnailUrl || '',
+        imageUrls: project.imageUrls || [],
         demoUrl: project.demoUrl || '',
         githubUrl: project.githubUrl || '',
         techStack: project.techStack || [],
@@ -104,6 +107,7 @@ export default function EditProjectPage() {
         techStack: formData.techStack,
       }
       if (formData.thumbnailUrl) payload.thumbnailUrl = formData.thumbnailUrl
+      payload.imageUrls = formData.imageUrls
       if (formData.demoUrl) payload.demoUrl = formData.demoUrl
       if (formData.githubUrl) payload.githubUrl = formData.githubUrl
       if (formData.tags.length > 0) payload.tags = formData.tags
@@ -195,6 +199,17 @@ export default function EditProjectPage() {
                   />
                 </FormField>
               </div>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 이미지 갤러리 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">이미지 갤러리</p>
+              <FormField label="갤러리 이미지">
+                <ImageGalleryUploader
+                  value={formData.imageUrls}
+                  onChange={(urls) => setFormData({ ...formData, imageUrls: urls })}
+                />
+              </FormField>
 
               <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
 

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -7,6 +7,7 @@ import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
 import { useToast } from '@/hooks/useToast'
 import TechStackInput from '@/components/TechStackInput'
 import ThumbnailUploader from '@/components/ThumbnailUploader'
+import ImageGalleryUploader from '@/components/ImageGalleryUploader'
 import FormField from '@/components/ui/FormField'
 import ErrorAlert from '@/components/ui/ErrorAlert'
 import Spinner from '@/components/ui/Spinner'
@@ -29,6 +30,7 @@ const EMPTY_FORM = {
   summary: '',
   description: '',
   thumbnailUrl: '',
+  imageUrls: [] as string[],
   demoUrl: '',
   githubUrl: '',
   techStack: [] as string[],
@@ -74,6 +76,7 @@ export default function NewProjectPage() {
         techStack: formData.techStack,
       }
       if (formData.thumbnailUrl) payload.thumbnailUrl = formData.thumbnailUrl
+      if (formData.imageUrls.length > 0) payload.imageUrls = formData.imageUrls
       if (formData.demoUrl) payload.demoUrl = formData.demoUrl
       if (formData.githubUrl) payload.githubUrl = formData.githubUrl
       if (formData.tags.length > 0) payload.tags = formData.tags
@@ -165,6 +168,17 @@ export default function NewProjectPage() {
                   />
                 </FormField>
               </div>
+
+              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+
+              {/* 이미지 갤러리 */}
+              <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">이미지 갤러리</p>
+              <FormField label="갤러리 이미지">
+                <ImageGalleryUploader
+                  value={formData.imageUrls}
+                  onChange={(urls) => setFormData({ ...formData, imageUrls: urls })}
+                />
+              </FormField>
 
               <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
 

--- a/components/ImageGalleryUploader.tsx
+++ b/components/ImageGalleryUploader.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import Image from 'next/image'
+
+const MAX_IMAGES = 10
+const MAX_SIZE_MB = 5
+
+interface ImageGalleryUploaderProps {
+  value: string[]
+  onChange: (urls: string[]) => void
+}
+
+export default function ImageGalleryUploader({ value, onChange }: ImageGalleryUploaderProps) {
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState('')
+  const [dragOver, setDragOver] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const supabase = createClient()
+
+  const uploadFiles = async (files: File[]) => {
+    setError('')
+    const remaining = MAX_IMAGES - value.length
+    if (remaining <= 0) {
+      setError(`최대 ${MAX_IMAGES}장까지 업로드할 수 있습니다.`)
+      return
+    }
+    const targets = files.slice(0, remaining)
+
+    const invalid = targets.find((f) => !f.type.startsWith('image/'))
+    if (invalid) { setError('이미지 파일만 업로드할 수 있습니다.'); return }
+    const oversized = targets.find((f) => f.size > MAX_SIZE_MB * 1024 * 1024)
+    if (oversized) { setError(`파일 크기는 ${MAX_SIZE_MB}MB 이하여야 합니다.`); return }
+
+    try {
+      setUploading(true)
+      const uploaded: string[] = []
+      for (const file of targets) {
+        const ext = file.name.split('.').pop()
+        const fileName = `gallery/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
+        const { error: uploadError } = await supabase.storage
+          .from('thumbnails')
+          .upload(fileName, file, { upsert: false })
+        if (uploadError) throw uploadError
+        const { data } = supabase.storage.from('thumbnails').getPublicUrl(fileName)
+        uploaded.push(data.publicUrl)
+      }
+      onChange([...value, ...uploaded])
+      if (files.length > remaining) {
+        setError(`${MAX_IMAGES}장 제한으로 ${remaining}장만 업로드됐습니다.`)
+      }
+    } catch {
+      setError('업로드에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    if (files.length) uploadFiles(files)
+    e.target.value = ''
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setDragOver(false)
+    const files = Array.from(e.dataTransfer.files)
+    if (files.length) uploadFiles(files)
+  }
+
+  const handleRemove = (idx: number) => {
+    onChange(value.filter((_, i) => i !== idx))
+    setError('')
+  }
+
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        multiple
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
+      {/* 이미지 그리드 */}
+      {value.length > 0 && (
+        <div className="mb-3 grid grid-cols-3 gap-2 sm:grid-cols-4">
+          {value.map((url, idx) => (
+            <div key={url} className="group relative aspect-square overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800">
+              <Image
+                src={url}
+                alt={`갤러리 이미지 ${idx + 1}`}
+                fill
+                sizes="(max-width: 640px) 33vw, 25vw"
+                className="object-cover"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemove(idx)}
+                className="absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition-opacity hover:bg-black/80 group-hover:opacity-100"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+              <span className="absolute bottom-1 left-1.5 rounded bg-black/50 px-1.5 py-0.5 text-[10px] text-white">{idx + 1}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 업로드 영역 */}
+      {value.length < MAX_IMAGES && (
+        <div
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={handleDrop}
+          onClick={() => !uploading && inputRef.current?.click()}
+          className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed py-6 transition-colors ${
+            dragOver
+              ? 'border-blue-400 bg-blue-50 dark:border-blue-500 dark:bg-blue-900/20'
+              : 'border-gray-200 bg-gray-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
+          }`}
+        >
+          {uploading ? (
+            <>
+              <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600" />
+              <p className="mt-2 text-sm text-gray-500">업로드 중...</p>
+            </>
+          ) : (
+            <>
+              <svg className={`h-8 w-8 ${dragOver ? 'text-blue-500' : 'text-gray-300 dark:text-gray-600'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              <p className="mt-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+                {dragOver ? '여기에 드롭하세요' : '클릭하거나 드래그해서 추가'}
+              </p>
+              <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                PNG, JPG, WebP, GIF · 최대 {MAX_SIZE_MB}MB · {value.length}/{MAX_IMAGES}장
+              </p>
+            </>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-1.5 flex items-center gap-1.5 text-xs text-red-500">
+          <svg className="h-3.5 w-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -45,6 +45,7 @@ export interface Project {
   summary: string;
   description: string; // Markdown
   thumbnailUrl?: string;
+  imageUrls?: string[];
   demoUrl?: string;
   githubUrl?: string;
   techStack: string[];
@@ -66,6 +67,7 @@ export interface CreateProjectRequest {
   summary: string;
   description: string;
   thumbnailUrl?: string;
+  imageUrls?: string[];
   demoUrl?: string;
   githubUrl?: string;
   techStack: string[];


### PR DESCRIPTION
## 관련 이슈
closes #92
Jira: FRONT-35

## 변경 유형
- [x] Feature

## 변경 내용
- `components/ImageGalleryUploader.tsx` 신규: Supabase Storage 직접 업로드, 최대 10장, 드래그앤드롭, 그리드 미리보기, 개별 삭제
- `app/projects/new/page.tsx`: 갤러리 업로더 섹션 추가, imageUrls payload 포함
- `app/projects/[id]/edit/page.tsx`: 동일 + 기존 imageUrls 불러오기
- `app/projects/[id]/ProjectDetailClient.tsx`: imageUrls 갤러리 그리드 표시 (클릭 시 원본 새 탭)
- `lib/types/api.ts`: Project, CreateProjectRequest에 imageUrls?: string[] 추가

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거