### PR TITLE
FRONT-39: feat: 댓글 더보기 페이지네이션 UI 추가

### DIFF
--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -9,6 +9,8 @@ import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
 
+const PAGE_SIZE = 10
+
 interface CommentSectionProps {
   targetType: 'project' | 'post'
   targetId: string
@@ -20,7 +22,11 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
   const { user, isAdmin } = useAuth()
   const isAuthenticated = !!user
   const [comments, setComments] = useState<Comment[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(false)
   const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [newComment, setNewComment] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
@@ -29,18 +35,38 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
   const [editSubmitting, setEditSubmitting] = useState(false)
 
   useEffect(() => {
-    loadComments()
+    loadInitial()
   }, [targetType, targetId])
 
-  const loadComments = async () => {
+  const loadInitial = async () => {
     try {
       setLoading(true)
-      const data = await getComments(targetType, targetId)
-      setComments(data)
+      const data = await getComments(targetType, targetId, 1, PAGE_SIZE)
+      setComments(data.items)
+      setTotal(data.total)
+      setPage(1)
+      setHasMore(data.page < data.totalPages)
     } catch {
       setComments([])
+      setTotal(0)
+      setHasMore(false)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const loadMore = async () => {
+    try {
+      setLoadingMore(true)
+      const nextPage = page + 1
+      const data = await getComments(targetType, targetId, nextPage, PAGE_SIZE)
+      setComments((prev) => [...prev, ...data.items])
+      setPage(nextPage)
+      setHasMore(nextPage < data.totalPages)
+    } catch {
+      showToast('댓글을 불러오지 못했습니다.', 'error')
+    } finally {
+      setLoadingMore(false)
     }
   }
 
@@ -61,7 +87,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       await updateComment(id, { content: editContent.trim() })
       setEditingId(null)
       setEditContent('')
-      await loadComments()
+      await loadInitial()
       showToast('댓글이 수정되었습니다.')
     } catch {
       showToast('댓글 수정에 실패했습니다. 다시 시도해주세요.', 'error')
@@ -75,7 +101,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
     try {
       await deleteComment(deleteTargetId)
       setDeleteTargetId(null)
-      await loadComments()
+      await loadInitial()
       showToast('댓글이 삭제되었습니다.')
     } catch {
       showToast('댓글 삭제에 실패했습니다. 다시 시도해주세요.', 'error')
@@ -91,7 +117,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       setSubmitting(true)
       await createComment(targetType, targetId, { content: newComment.trim() })
       setNewComment('')
-      await loadComments()
+      await loadInitial()
       showToast('댓글이 등록되었습니다.')
     } catch {
       showToast('댓글 등록에 실패했습니다. 다시 시도해주세요.', 'error')
@@ -108,7 +134,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
         </svg>
         <h3 className="text-lg font-bold text-gray-900 dark:text-white">
-          댓글 <span className="text-gray-400 dark:text-gray-500">{comments.length}</span>
+          댓글 <span className="text-gray-400 dark:text-gray-500">{total}</span>
         </h3>
       </div>
 
@@ -170,96 +196,124 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
           <p className="text-sm text-gray-400 dark:text-gray-500">첫 댓글을 작성해보세요!</p>
         </div>
       ) : (
-        <div className="space-y-3">
-          {comments.map((comment) => (
-            <div
-              key={comment.id}
-              className="rounded-xl border border-gray-100 bg-gray-50 p-4 dark:border-gray-700/50 dark:bg-gray-900"
-            >
-              <div className="mb-2 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  {/* 아바타 이니셜 */}
-                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-500 text-xs font-bold text-white">
-                    {comment.user.nickname.charAt(0).toUpperCase()}
-                  </div>
-                  <span className="text-sm font-semibold text-gray-900 dark:text-white">
-                    {comment.user.nickname}
-                  </span>
-                  {comment.isAnonymous && (
-                    <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-500 dark:bg-gray-700 dark:text-gray-400">
-                      익명
+        <>
+          <div className="space-y-3">
+            {comments.map((comment) => (
+              <div
+                key={comment.id}
+                className="rounded-xl border border-gray-100 bg-gray-50 p-4 dark:border-gray-700/50 dark:bg-gray-900"
+              >
+                <div className="mb-2 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    {/* 아바타 이니셜 */}
+                    <div className="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-500 text-xs font-bold text-white">
+                      {comment.user.nickname.charAt(0).toUpperCase()}
+                    </div>
+                    <span className="text-sm font-semibold text-gray-900 dark:text-white">
+                      {comment.user.nickname}
                     </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-gray-400 dark:text-gray-500">
-                    {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
-                  </span>
-                  {comment.isMine && editingId !== comment.id && (
-                    <button
-                      type="button"
-                      onClick={() => handleEditStart(comment)}
-                      className="rounded p-0.5 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
-                      aria-label="댓글 수정"
-                    >
-                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                      </svg>
-                    </button>
-                  )}
-                  {(comment.isMine || isAdmin) && editingId !== comment.id && (
-                    <button
-                      type="button"
-                      onClick={() => setDeleteTargetId(comment.id)}
-                      className="rounded p-0.5 text-gray-300 transition-colors hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400"
-                      aria-label="댓글 삭제"
-                    >
-                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                      </svg>
-                    </button>
-                  )}
-                </div>
-              </div>
-              {editingId === comment.id ? (
-                <div className="pl-9">
-                  <textarea
-                    value={editContent}
-                    onChange={(e) => setEditContent(e.target.value)}
-                    rows={3}
-                    className="w-full resize-none rounded-lg border border-blue-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-blue-500 dark:bg-gray-800 dark:text-gray-200"
-                  />
-                  <div className="mt-2 flex items-center justify-end gap-2">
-                    <button
-                      type="button"
-                      onClick={handleEditCancel}
-                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
-                    >
-                      취소
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleEditSave(comment.id)}
-                      disabled={editSubmitting || !editContent.trim() || editContent.trim() === comment.content}
-                      className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {editSubmitting ? (
-                        <>
-                          <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                          저장 중
-                        </>
-                      ) : '저장'}
-                    </button>
+                    {comment.isAnonymous && (
+                      <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                        익명
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                      {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
+                    </span>
+                    {comment.isMine && editingId !== comment.id && (
+                      <button
+                        type="button"
+                        onClick={() => handleEditStart(comment)}
+                        className="rounded p-0.5 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
+                        aria-label="댓글 수정"
+                      >
+                        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                        </svg>
+                      </button>
+                    )}
+                    {(comment.isMine || isAdmin) && editingId !== comment.id && (
+                      <button
+                        type="button"
+                        onClick={() => setDeleteTargetId(comment.id)}
+                        className="rounded p-0.5 text-gray-300 transition-colors hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400"
+                        aria-label="댓글 삭제"
+                      >
+                        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                      </button>
+                    )}
                   </div>
                 </div>
-              ) : (
-                <p className="whitespace-pre-wrap pl-9 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-                  {comment.content}
-                </p>
-              )}
+                {editingId === comment.id ? (
+                  <div className="pl-9">
+                    <textarea
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                      rows={3}
+                      className="w-full resize-none rounded-lg border border-blue-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-blue-500 dark:bg-gray-800 dark:text-gray-200"
+                    />
+                    <div className="mt-2 flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={handleEditCancel}
+                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+                      >
+                        취소
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleEditSave(comment.id)}
+                        disabled={editSubmitting || !editContent.trim() || editContent.trim() === comment.content}
+                        className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {editSubmitting ? (
+                          <>
+                            <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                            저장 중
+                          </>
+                        ) : '저장'}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="whitespace-pre-wrap pl-9 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+                    {comment.content}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 더보기 버튼 */}
+          {hasMore && (
+            <div className="mt-4 flex justify-center">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="flex items-center gap-2 rounded-lg border border-gray-200 px-5 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+              >
+                {loadingMore ? (
+                  <>
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+                    불러오는 중
+                  </>
+                ) : (
+                  <>
+                    더보기
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                      ({comments.length}/{total})
+                    </span>
+                  </>
+                )}
+              </button>
             </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
 
       <ConfirmDialog

--- a/lib/api/comments.ts
+++ b/lib/api/comments.ts
@@ -4,31 +4,34 @@ import type {
   CommentTargetType,
   CreateCommentRequest,
   UpdateCommentRequest,
+  PaginatedResponse,
 } from '@/lib/types/api'
 
 // ============================================
 // Re-export Types
 // ============================================
-export type { 
-  Comment, 
-  CommentTargetType, 
-  CreateCommentRequest, 
-  UpdateCommentRequest 
+export type {
+  Comment,
+  CommentTargetType,
+  CreateCommentRequest,
+  UpdateCommentRequest
 }
 
 // ============================================
 // Comments API
 // ============================================
 
-/**
- * 댓글 목록 조회 (익명 마스킹 적용)
- */
 export async function getComments(
   targetType: CommentTargetType,
-  targetId: string
-): Promise<Comment[]> {
-  const response = await api.get<{ items: Comment[] }>(`/comments/${targetType}/${targetId}`)
-  return response.data.items
+  targetId: string,
+  page = 1,
+  limit = 10
+): Promise<PaginatedResponse<Comment>> {
+  const response = await api.get<PaginatedResponse<Comment>>(
+    `/comments/${targetType}/${targetId}`,
+    { params: { page, limit } }
+  )
+  return response.data
 }
 
 /**


### PR DESCRIPTION
## 관련 이슈
closes #104
Jira: FRONT-39

## 변경 유형
- [x] Feature

## 변경 내용

### `lib/api/comments.ts`
- `getComments`에 `page`, `limit` 파라미터 추가 (기본값: page=1, limit=10)
- 반환 타입을 `Comment[]` → `PaginatedResponse<Comment>`로 변경

### `components/CommentSection.tsx`
- 초기 로드 시 10개만 표시 (`loadInitial`)
- '더보기' 버튼 클릭 시 다음 페이지 누적 로드 (`loadMore`)
- 헤더 댓글 수를 `comments.length` → `total`(전체 수) 기준으로 변경
- 마지막 페이지 도달 시 더보기 버튼 숨김
- 작성/수정/삭제 후 1페이지부터 재로드 (`loadInitial` 재호출)

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거