### PR TITLE
Sprint 10 릴리즈: FRONT-35, 37, 39

### DIFF
--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -15,6 +15,7 @@ import { ko } from 'date-fns/locale'
 import Image from 'next/image'
 import api from '@/lib/api/client'
 import { useToast } from '@/hooks/useToast'
+import UpdateTimeline from '@/components/UpdateTimeline'
 
 interface Props {
   project: Project
@@ -273,6 +274,8 @@ export default function ProjectDetailClient({ project, from }: Props) {
               )}
             </div>
           )}
+
+          <UpdateTimeline projectId={project.id} />
 
           {/* 실시간 영역 — 클라이언트에서 별도 fetch */}
           <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700">

--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -9,6 +9,8 @@ import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
 
+const PAGE_SIZE = 10
+
 interface CommentSectionProps {
   targetType: 'project' | 'post'
   targetId: string
@@ -20,7 +22,11 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
   const { user, isAdmin } = useAuth()
   const isAuthenticated = !!user
   const [comments, setComments] = useState<Comment[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(false)
   const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [newComment, setNewComment] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
@@ -29,18 +35,38 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
   const [editSubmitting, setEditSubmitting] = useState(false)
 
   useEffect(() => {
-    loadComments()
+    loadInitial()
   }, [targetType, targetId])
 
-  const loadComments = async () => {
+  const loadInitial = async () => {
     try {
       setLoading(true)
-      const data = await getComments(targetType, targetId)
-      setComments(data)
+      const data = await getComments(targetType, targetId, 1, PAGE_SIZE)
+      setComments(data.items)
+      setTotal(data.total)
+      setPage(1)
+      setHasMore(data.page < data.totalPages)
     } catch {
       setComments([])
+      setTotal(0)
+      setHasMore(false)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const loadMore = async () => {
+    try {
+      setLoadingMore(true)
+      const nextPage = page + 1
+      const data = await getComments(targetType, targetId, nextPage, PAGE_SIZE)
+      setComments((prev) => [...prev, ...data.items])
+      setPage(nextPage)
+      setHasMore(nextPage < data.totalPages)
+    } catch {
+      showToast('댓글을 불러오지 못했습니다.', 'error')
+    } finally {
+      setLoadingMore(false)
     }
   }
 
@@ -61,7 +87,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       await updateComment(id, { content: editContent.trim() })
       setEditingId(null)
       setEditContent('')
-      await loadComments()
+      await loadInitial()
       showToast('댓글이 수정되었습니다.')
     } catch {
       showToast('댓글 수정에 실패했습니다. 다시 시도해주세요.', 'error')
@@ -75,7 +101,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
     try {
       await deleteComment(deleteTargetId)
       setDeleteTargetId(null)
-      await loadComments()
+      await loadInitial()
       showToast('댓글이 삭제되었습니다.')
     } catch {
       showToast('댓글 삭제에 실패했습니다. 다시 시도해주세요.', 'error')
@@ -91,7 +117,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       setSubmitting(true)
       await createComment(targetType, targetId, { content: newComment.trim() })
       setNewComment('')
-      await loadComments()
+      await loadInitial()
       showToast('댓글이 등록되었습니다.')
     } catch {
       showToast('댓글 등록에 실패했습니다. 다시 시도해주세요.', 'error')
@@ -108,7 +134,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
         </svg>
         <h3 className="text-lg font-bold text-gray-900 dark:text-white">
-          댓글 <span className="text-gray-400 dark:text-gray-500">{comments.length}</span>
+          댓글 <span className="text-gray-400 dark:text-gray-500">{total}</span>
         </h3>
       </div>
 
@@ -170,96 +196,124 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
           <p className="text-sm text-gray-400 dark:text-gray-500">첫 댓글을 작성해보세요!</p>
         </div>
       ) : (
-        <div className="space-y-3">
-          {comments.map((comment) => (
-            <div
-              key={comment.id}
-              className="rounded-xl border border-gray-100 bg-gray-50 p-4 dark:border-gray-700/50 dark:bg-gray-900"
-            >
-              <div className="mb-2 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  {/* 아바타 이니셜 */}
-                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-500 text-xs font-bold text-white">
-                    {comment.user.nickname.charAt(0).toUpperCase()}
-                  </div>
-                  <span className="text-sm font-semibold text-gray-900 dark:text-white">
-                    {comment.user.nickname}
-                  </span>
-                  {comment.isAnonymous && (
-                    <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-500 dark:bg-gray-700 dark:text-gray-400">
-                      익명
+        <>
+          <div className="space-y-3">
+            {comments.map((comment) => (
+              <div
+                key={comment.id}
+                className="rounded-xl border border-gray-100 bg-gray-50 p-4 dark:border-gray-700/50 dark:bg-gray-900"
+              >
+                <div className="mb-2 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    {/* 아바타 이니셜 */}
+                    <div className="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-500 text-xs font-bold text-white">
+                      {comment.user.nickname.charAt(0).toUpperCase()}
+                    </div>
+                    <span className="text-sm font-semibold text-gray-900 dark:text-white">
+                      {comment.user.nickname}
                     </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-gray-400 dark:text-gray-500">
-                    {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
-                  </span>
-                  {comment.isMine && editingId !== comment.id && (
-                    <button
-                      type="button"
-                      onClick={() => handleEditStart(comment)}
-                      className="rounded p-0.5 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
-                      aria-label="댓글 수정"
-                    >
-                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                      </svg>
-                    </button>
-                  )}
-                  {(comment.isMine || isAdmin) && editingId !== comment.id && (
-                    <button
-                      type="button"
-                      onClick={() => setDeleteTargetId(comment.id)}
-                      className="rounded p-0.5 text-gray-300 transition-colors hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400"
-                      aria-label="댓글 삭제"
-                    >
-                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                      </svg>
-                    </button>
-                  )}
-                </div>
-              </div>
-              {editingId === comment.id ? (
-                <div className="pl-9">
-                  <textarea
-                    value={editContent}
-                    onChange={(e) => setEditContent(e.target.value)}
-                    rows={3}
-                    className="w-full resize-none rounded-lg border border-blue-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-blue-500 dark:bg-gray-800 dark:text-gray-200"
-                  />
-                  <div className="mt-2 flex items-center justify-end gap-2">
-                    <button
-                      type="button"
-                      onClick={handleEditCancel}
-                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
-                    >
-                      취소
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleEditSave(comment.id)}
-                      disabled={editSubmitting || !editContent.trim() || editContent.trim() === comment.content}
-                      className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {editSubmitting ? (
-                        <>
-                          <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                          저장 중
-                        </>
-                      ) : '저장'}
-                    </button>
+                    {comment.isAnonymous && (
+                      <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                        익명
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                      {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
+                    </span>
+                    {comment.isMine && editingId !== comment.id && (
+                      <button
+                        type="button"
+                        onClick={() => handleEditStart(comment)}
+                        className="rounded p-0.5 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
+                        aria-label="댓글 수정"
+                      >
+                        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                        </svg>
+                      </button>
+                    )}
+                    {(comment.isMine || isAdmin) && editingId !== comment.id && (
+                      <button
+                        type="button"
+                        onClick={() => setDeleteTargetId(comment.id)}
+                        className="rounded p-0.5 text-gray-300 transition-colors hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400"
+                        aria-label="댓글 삭제"
+                      >
+                        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                      </button>
+                    )}
                   </div>
                 </div>
-              ) : (
-                <p className="whitespace-pre-wrap pl-9 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-                  {comment.content}
-                </p>
-              )}
+                {editingId === comment.id ? (
+                  <div className="pl-9">
+                    <textarea
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                      rows={3}
+                      className="w-full resize-none rounded-lg border border-blue-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-blue-500 dark:bg-gray-800 dark:text-gray-200"
+                    />
+                    <div className="mt-2 flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={handleEditCancel}
+                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+                      >
+                        취소
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleEditSave(comment.id)}
+                        disabled={editSubmitting || !editContent.trim() || editContent.trim() === comment.content}
+                        className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {editSubmitting ? (
+                          <>
+                            <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                            저장 중
+                          </>
+                        ) : '저장'}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="whitespace-pre-wrap pl-9 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+                    {comment.content}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 더보기 버튼 */}
+          {hasMore && (
+            <div className="mt-4 flex justify-center">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="flex items-center gap-2 rounded-lg border border-gray-200 px-5 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+              >
+                {loadingMore ? (
+                  <>
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+                    불러오는 중
+                  </>
+                ) : (
+                  <>
+                    더보기
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                      ({comments.length}/{total})
+                    </span>
+                  </>
+                )}
+              </button>
             </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
 
       <ConfirmDialog

--- a/components/UpdateTimeline.tsx
+++ b/components/UpdateTimeline.tsx
@@ -1,0 +1,356 @@
+'use client'
+
+import { useState, useEffect, useMemo } from 'react'
+import ReactMarkdown from 'react-markdown'
+import type { Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { formatDistanceToNow } from 'date-fns'
+import { ko } from 'date-fns/locale'
+import { getUpdates, createUpdate, updateUpdate, deleteUpdate, type ProjectUpdate } from '@/lib/api/updates'
+import { useAuth } from '@/hooks/useAuth'
+import { useToast } from '@/hooks/useToast'
+import ConfirmDialog from '@/components/ui/ConfirmDialog'
+
+interface Props {
+  projectId: string
+}
+
+export default function UpdateTimeline({ projectId }: Props) {
+  const { isAdmin } = useAuth()
+  const { showToast } = useToast()
+
+  const [updates, setUpdates] = useState<ProjectUpdate[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // 추가 폼
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [addTitle, setAddTitle] = useState('')
+  const [addContent, setAddContent] = useState('')
+  const [addExternalUrl, setAddExternalUrl] = useState('')
+  const [addSubmitting, setAddSubmitting] = useState(false)
+
+  // 수정
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editTitle, setEditTitle] = useState('')
+  const [editContent, setEditContent] = useState('')
+  const [editExternalUrl, setEditExternalUrl] = useState('')
+  const [editSubmitting, setEditSubmitting] = useState(false)
+
+  // 삭제
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
+
+  useEffect(() => {
+    load()
+  }, [projectId])
+
+  const load = async () => {
+    try {
+      setLoading(true)
+      const data = await getUpdates(projectId)
+      setUpdates(data)
+    } catch {
+      setUpdates([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!addTitle.trim() || !addContent.trim()) return
+    try {
+      setAddSubmitting(true)
+      await createUpdate(projectId, {
+        title: addTitle.trim(),
+        content: addContent.trim(),
+        ...(addExternalUrl.trim() ? { externalUrl: addExternalUrl.trim() } : {}),
+      })
+      setShowAddForm(false)
+      setAddTitle('')
+      setAddContent('')
+      setAddExternalUrl('')
+      await load()
+      showToast('업데이트가 등록되었습니다.')
+    } catch {
+      showToast('등록에 실패했습니다. 다시 시도해주세요.', 'error')
+    } finally {
+      setAddSubmitting(false)
+    }
+  }
+
+  const handleEditStart = (item: ProjectUpdate) => {
+    setEditingId(item.id)
+    setEditTitle(item.title)
+    setEditContent(item.content)
+    setEditExternalUrl(item.externalUrl ?? '')
+  }
+
+  const handleEditCancel = () => {
+    setEditingId(null)
+    setEditTitle('')
+    setEditContent('')
+    setEditExternalUrl('')
+  }
+
+  const handleEditSave = async (id: string) => {
+    if (!editTitle.trim() || !editContent.trim()) return
+    try {
+      setEditSubmitting(true)
+      await updateUpdate(id, {
+        title: editTitle.trim(),
+        content: editContent.trim(),
+        ...(editExternalUrl.trim() ? { externalUrl: editExternalUrl.trim() } : { externalUrl: undefined }),
+      })
+      handleEditCancel()
+      await load()
+      showToast('업데이트가 수정되었습니다.')
+    } catch {
+      showToast('수정에 실패했습니다. 다시 시도해주세요.', 'error')
+    } finally {
+      setEditSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deleteTargetId) return
+    try {
+      await deleteUpdate(deleteTargetId)
+      setDeleteTargetId(null)
+      await load()
+      showToast('업데이트가 삭제되었습니다.')
+    } catch {
+      showToast('삭제에 실패했습니다. 다시 시도해주세요.', 'error')
+    }
+  }
+
+  const markdownComponents: Components = useMemo(() => ({
+    table: ({ children }) => (
+      <div className="overflow-x-auto"><table>{children}</table></div>
+    ),
+  }), [])
+
+  const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-blue-500'
+
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:p-8">
+      {/* 헤더 */}
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <svg className="h-5 w-5 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <h3 className="text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            Changelog
+          </h3>
+        </div>
+        {isAdmin && !showAddForm && (
+          <button
+            type="button"
+            onClick={() => setShowAddForm(true)}
+            className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+            추가
+          </button>
+        )}
+      </div>
+
+      {/* 추가 폼 */}
+      {isAdmin && showAddForm && (
+        <form onSubmit={handleAdd} className="mb-6 rounded-xl border border-blue-200 bg-blue-50/50 p-4 dark:border-blue-800/50 dark:bg-blue-900/10">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-blue-600 dark:text-blue-400">새 업데이트</p>
+          <div className="space-y-2.5">
+            <input
+              type="text"
+              value={addTitle}
+              onChange={(e) => setAddTitle(e.target.value)}
+              placeholder="제목"
+              className={inputClass}
+            />
+            <textarea
+              value={addContent}
+              onChange={(e) => setAddContent(e.target.value)}
+              placeholder="내용 (Markdown 지원)"
+              rows={4}
+              className={`${inputClass} resize-none`}
+            />
+            <input
+              type="url"
+              value={addExternalUrl}
+              onChange={(e) => setAddExternalUrl(e.target.value)}
+              placeholder="관련 URL (선택, PR 링크·배포 링크 등)"
+              className={inputClass}
+            />
+          </div>
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => { setShowAddForm(false); setAddTitle(''); setAddContent(''); setAddExternalUrl('') }}
+              className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={addSubmitting || !addTitle.trim() || !addContent.trim()}
+              className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {addSubmitting ? (
+                <>
+                  <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                  등록 중
+                </>
+              ) : '등록'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* 타임라인 목록 */}
+      {loading ? (
+        <div className="flex justify-center py-8">
+          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600" />
+        </div>
+      ) : updates.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700">
+          <svg className="mx-auto mb-3 h-10 w-10 text-gray-300 dark:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <p className="text-sm text-gray-400 dark:text-gray-500">아직 업데이트 내역이 없습니다.</p>
+        </div>
+      ) : (
+        <ol className="relative border-l border-gray-200 dark:border-gray-700">
+          {updates.map((item) => (
+            <li key={item.id} className="mb-8 ml-4 last:mb-0">
+              {/* 타임라인 점 */}
+              <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-white bg-blue-500 dark:border-gray-800 dark:bg-blue-400" />
+
+              {editingId === item.id ? (
+                /* 수정 폼 */
+                <div className="rounded-xl border border-blue-200 bg-blue-50/50 p-4 dark:border-blue-800/50 dark:bg-blue-900/10">
+                  <div className="space-y-2.5">
+                    <input
+                      type="text"
+                      value={editTitle}
+                      onChange={(e) => setEditTitle(e.target.value)}
+                      className={inputClass}
+                    />
+                    <textarea
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                      rows={4}
+                      className={`${inputClass} resize-none`}
+                    />
+                    <input
+                      type="url"
+                      value={editExternalUrl}
+                      onChange={(e) => setEditExternalUrl(e.target.value)}
+                      placeholder="관련 URL (선택)"
+                      className={inputClass}
+                    />
+                  </div>
+                  <div className="mt-3 flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={handleEditCancel}
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+                    >
+                      취소
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleEditSave(item.id)}
+                      disabled={
+                        editSubmitting ||
+                        !editTitle.trim() ||
+                        !editContent.trim() ||
+                        (editTitle.trim() === item.title && editContent.trim() === item.content && editExternalUrl.trim() === (item.externalUrl ?? ''))
+                      }
+                      className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {editSubmitting ? (
+                        <>
+                          <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                          저장 중
+                        </>
+                      ) : '저장'}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                /* 읽기 뷰 */
+                <div>
+                  <div className="mb-1 flex flex-wrap items-start justify-between gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h4 className="text-sm font-semibold text-gray-900 dark:text-white">{item.title}</h4>
+                      {item.externalUrl && (
+                        <a
+                          href={item.externalUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
+                        >
+                          <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                          </svg>
+                          링크
+                        </a>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <time className="text-xs text-gray-400 dark:text-gray-500">
+                        {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true, locale: ko })}
+                      </time>
+                      {isAdmin && (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => handleEditStart(item)}
+                            className="rounded p-0.5 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
+                            aria-label="수정"
+                          >
+                            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                            </svg>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setDeleteTargetId(item.id)}
+                            className="rounded p-0.5 text-gray-300 transition-colors hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400"
+                            aria-label="삭제"
+                          >
+                            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                            </svg>
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <div className="markdown-body text-sm">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                      {item.content}
+                    </ReactMarkdown>
+                  </div>
+                </div>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <ConfirmDialog
+        open={!!deleteTargetId}
+        title="업데이트 삭제"
+        description="이 업데이트 내역을 삭제하시겠습니까? 삭제된 내용은 복구할 수 없습니다."
+        confirmLabel="삭제"
+        cancelLabel="취소"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTargetId(null)}
+      />
+    </section>
+  )
+}

--- a/lib/api/comments.ts
+++ b/lib/api/comments.ts
@@ -4,31 +4,34 @@ import type {
   CommentTargetType,
   CreateCommentRequest,
   UpdateCommentRequest,
+  PaginatedResponse,
 } from '@/lib/types/api'
 
 // ============================================
 // Re-export Types
 // ============================================
-export type { 
-  Comment, 
-  CommentTargetType, 
-  CreateCommentRequest, 
-  UpdateCommentRequest 
+export type {
+  Comment,
+  CommentTargetType,
+  CreateCommentRequest,
+  UpdateCommentRequest
 }
 
 // ============================================
 // Comments API
 // ============================================
 
-/**
- * 댓글 목록 조회 (익명 마스킹 적용)
- */
 export async function getComments(
   targetType: CommentTargetType,
-  targetId: string
-): Promise<Comment[]> {
-  const response = await api.get<{ items: Comment[] }>(`/comments/${targetType}/${targetId}`)
-  return response.data.items
+  targetId: string,
+  page = 1,
+  limit = 10
+): Promise<PaginatedResponse<Comment>> {
+  const response = await api.get<PaginatedResponse<Comment>>(
+    `/comments/${targetType}/${targetId}`,
+    { params: { page, limit } }
+  )
+  return response.data
 }
 
 /**

--- a/lib/api/updates.ts
+++ b/lib/api/updates.ts
@@ -1,0 +1,33 @@
+import api from './client'
+import type {
+  ProjectUpdate,
+  CreateProjectUpdateRequest,
+  UpdateProjectUpdateRequest,
+} from '@/lib/types/api'
+
+export type { ProjectUpdate }
+
+export async function getUpdates(projectId: string): Promise<ProjectUpdate[]> {
+  const res = await api.get<ProjectUpdate[]>(`/projects/${projectId}/updates`)
+  return res.data
+}
+
+export async function createUpdate(
+  projectId: string,
+  data: CreateProjectUpdateRequest
+): Promise<ProjectUpdate> {
+  const res = await api.post<ProjectUpdate>(`/projects/${projectId}/updates`, data)
+  return res.data
+}
+
+export async function updateUpdate(
+  updateId: string,
+  data: UpdateProjectUpdateRequest
+): Promise<ProjectUpdate> {
+  const res = await api.patch<ProjectUpdate>(`/projects/updates/${updateId}`, data)
+  return res.data
+}
+
+export async function deleteUpdate(updateId: string): Promise<void> {
+  await api.delete(`/projects/updates/${updateId}`)
+}

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -163,6 +163,30 @@ export interface UpdateCommentRequest {
 }
 
 // ============================================
+// Project Update (Changelog)
+// ============================================
+
+export type UpdateType = 'MANUAL' | 'GITHUB_PR';
+
+export interface ProjectUpdate {
+  id: string;
+  projectId: string;
+  updateType: UpdateType;
+  title: string;
+  content: string;
+  externalUrl: string | null;
+  createdAt: string;
+}
+
+export interface CreateProjectUpdateRequest {
+  title: string;
+  content: string;
+  externalUrl?: string;
+}
+
+export type UpdateProjectUpdateRequest = Partial<CreateProjectUpdateRequest>;
+
+// ============================================
 // Like
 // ============================================
 


### PR DESCRIPTION
## 릴리즈 버전
Sprint 10

## 배포 개요
프로젝트 이미지 갤러리, 로컬 인증 UI 제거, 댓글 더보기 페이지네이션 기능을 main에 반영합니다.

## 포함된 PR
- #94 FRONT-34: fix: 프로젝트 썸네일 잘림 문제 수정
- #95 #96 FRONT-33: fix: 모바일 프로젝트·블로그 상세 가독성 개선
- #97 FRONT-36: refactor: 에디터 폼 섹션 구조 개선 및 블로그 편집 페이지 통일
- #98 fix: 댓글 API 페이지네이션 응답 처리 수정 (hotfix)
- #101 FRONT-37: refactor: 로컬 인증 UI 및 관련 코드 제거
- #102 FRONT-35: feat: 프로젝트 이미지 갤러리 기능 추가
- #105 FRONT-39: feat: 댓글 더보기 페이지네이션 UI 추가

## 체크리스트
- [ ] develop Preview URL에서 전체 기능 확인
- [ ] 모바일 실기기 확인
- [ ] 다크모드 확인
- [ ] 콘솔 에러 없음
- [ ] 환경변수 Vercel 설정 확인

## 머지 대상
`develop` → `main`