### PR TITLE
FRONT-42: refactor: 홈 페이지 정적 데이터 lib/data/ 분리

### DIFF
--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -1,12 +1,4 @@
-const educations = [
-  {
-    id: 1,
-    period: '2025.05 ~ 2025.08',
-    course: 'Intel AI Master 임베디드 과정',
-    org: '청년취업사관학교',
-    desc: '리눅스 기반 임베디드 환경에서 카메라·통신(UART/SPI/I2C) 기초, OpenCV 영상처리, OpenVINO 기반 AI 추론·최적화, Geti/OTX를 활용한 MLOps 흐름, Docker·Git 협업, LLM·RAG 시스템 기초를 학습했습니다.',
-  },
-]
+import educations from '@/lib/data/education'
 
 export default function Education() {
   return (
@@ -25,7 +17,20 @@ export default function Education() {
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{edu.course}</span>
                 <span className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:text-sm">{edu.period}</span>
               </div>
-              <strong className="mb-2 block text-sm font-semibold text-blue-600 dark:text-blue-400 sm:mb-3 sm:text-base">{edu.org}</strong>
+              {edu.url ? (
+                <a
+                  href={edu.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mb-2 block text-sm font-semibold text-blue-600 underline-offset-2 hover:underline dark:text-blue-400 sm:mb-3 sm:text-base"
+                >
+                  {edu.org}
+                </a>
+              ) : (
+                <strong className="mb-2 block text-sm font-semibold text-blue-600 dark:text-blue-400 sm:mb-3 sm:text-base">
+                  {edu.org}
+                </strong>
+              )}
               <p className="text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:text-[1.05rem]">{edu.desc}</p>
             </div>
           ))}

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -1,12 +1,4 @@
-const experiences = [
-  {
-    id: 1,
-    period: '2025.09 ~ 2025.10',
-    role: '일경험 인턴',
-    org: '서울현대교육재단 (Zest CNS Co., Ltd.)',
-    desc: 'Spring MVC(JSP) 기반 게시판 예제를 통해 백엔드 CRUD 흐름을 학습하고, REST API로 분리하여 React·Vue 프론트엔드와 연동하는 과정을 실습했습니다.',
-  },
-]
+import experiences from '@/lib/data/experience'
 
 export default function Experience() {
   return (
@@ -25,7 +17,20 @@ export default function Experience() {
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{exp.role}</span>
                 <span className="text-xs font-medium text-gray-400 dark:text-gray-500 sm:text-sm">{exp.period}</span>
               </div>
-              <strong className="mb-2 block text-sm font-semibold text-blue-600 dark:text-blue-400 sm:mb-3 sm:text-base">{exp.org}</strong>
+              {exp.url ? (
+                <a
+                  href={exp.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mb-2 block text-sm font-semibold text-blue-600 underline-offset-2 hover:underline dark:text-blue-400 sm:mb-3 sm:text-base"
+                >
+                  {exp.org}
+                </a>
+              ) : (
+                <strong className="mb-2 block text-sm font-semibold text-blue-600 dark:text-blue-400 sm:mb-3 sm:text-base">
+                  {exp.org}
+                </strong>
+              )}
               <p className="text-sm leading-relaxed text-gray-500 dark:text-gray-400 sm:text-[1.05rem]">{exp.desc}</p>
             </div>
           ))}

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -1,43 +1,4 @@
-import { FaLaptopCode, FaRobot, FaMicrochip, FaServer } from 'react-icons/fa'
-
-const skillCategories = [
-  {
-    icon: FaLaptopCode,
-    title: 'Languages & Core',
-    items: [
-      'Java, Python, C, C++, JavaScript / TypeScript',
-      'Linux 개발 환경, Syscall 및 인터럽트 이해',
-    ],
-  },
-  {
-    icon: FaRobot,
-    title: 'AI & Data',
-    items: [
-      'Python (PyTorch, TensorFlow) 모델 학습 및 추론',
-      'OpenCV 영상 전처리 & OpenVINO 최적화',
-      'PyTorch → ONNX → HEF 변환 (Edge AI 가속기 적용)',
-      'MLOps 기반 모델 CI/CD 파이프라인 구축',
-    ],
-  },
-  {
-    icon: FaMicrochip,
-    title: 'Embedded & Hardware',
-    items: [
-      'RFID ↔ Raspberry Pi 5 간 SPI 통신',
-      '드라이버 API 활용 카메라 동작/출력 설정',
-    ],
-  },
-  {
-    icon: FaServer,
-    title: 'Web & DevOps',
-    items: [
-      'NestJS, Next.js, Spring, React 활용',
-      'REST API 설계 및 JSON 기반 HTTP 통신',
-      'Docker (Dockerfile, Compose) 컨테이너 배포',
-      'GitHub Actions CI/CD & Branch Protection',
-    ],
-  },
-]
+import skills from '@/lib/data/skills'
 
 export default function Skills() {
   return (
@@ -47,17 +8,15 @@ export default function Skills() {
           Skills & Capabilities
         </h2>
         <div className="grid gap-4 sm:grid-cols-2 sm:gap-6">
-          {skillCategories.map(({ icon: Icon, title, items }) => (
+          {skills.map(({ icon: Icon, title, items }) => (
             <div
               key={title}
               className="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:-translate-y-1 hover:border-blue-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/60 dark:hover:border-blue-500 sm:p-6"
             >
-              {/* 카드 헤더 */}
               <div className="mb-3 flex items-center gap-3 border-b border-gray-100 pb-3 dark:border-gray-700 sm:mb-4">
                 <Icon className="text-lg text-blue-600 dark:text-blue-400 sm:text-xl" />
                 <h3 className="text-sm font-bold text-gray-900 dark:text-white sm:text-base">{title}</h3>
               </div>
-              {/* 아이템 리스트 */}
               <ul className="space-y-1.5 sm:space-y-2">
                 {items.map((item) => (
                   <li key={item} className="text-xs leading-relaxed text-gray-500 dark:text-gray-400 sm:text-sm">

--- a/lib/data/education.ts
+++ b/lib/data/education.ts
@@ -1,0 +1,21 @@
+export interface EducationItem {
+  id: number
+  period: string
+  course: string
+  org: string
+  desc: string
+  /** 기관 링크 (선택) */
+  url?: string
+}
+
+const educations: EducationItem[] = [
+  {
+    id: 1,
+    period: '2025.05 ~ 2025.08',
+    course: 'Intel AI Master 임베디드 과정',
+    org: '청년취업사관학교',
+    desc: '리눅스 기반 임베디드 환경에서 카메라·통신(UART/SPI/I2C) 기초, OpenCV 영상처리, OpenVINO 기반 AI 추론·최적화, Geti/OTX를 활용한 MLOps 흐름, Docker·Git 협업, LLM·RAG 시스템 기초를 학습했습니다.',
+  },
+]
+
+export default educations

--- a/lib/data/experience.ts
+++ b/lib/data/experience.ts
@@ -1,0 +1,21 @@
+export interface ExperienceItem {
+  id: number
+  period: string
+  role: string
+  org: string
+  desc: string
+  /** 회사/기관 링크 (선택) */
+  url?: string
+}
+
+const experiences: ExperienceItem[] = [
+  {
+    id: 1,
+    period: '2025.09 ~ 2025.10',
+    role: '일경험 인턴',
+    org: '서울현대교육재단 (Zest CNS Co., Ltd.)',
+    desc: 'Spring MVC(JSP) 기반 게시판 예제를 통해 백엔드 CRUD 흐름을 학습하고, REST API로 분리하여 React·Vue 프론트엔드와 연동하는 과정을 실습했습니다.',
+  },
+]
+
+export default experiences

--- a/lib/data/skills.ts
+++ b/lib/data/skills.ts
@@ -1,0 +1,49 @@
+import { FaLaptopCode, FaRobot, FaMicrochip, FaServer } from 'react-icons/fa'
+import type { IconType } from 'react-icons'
+
+export interface SkillCategory {
+  icon: IconType
+  title: string
+  items: string[]
+}
+
+const skills: SkillCategory[] = [
+  {
+    icon: FaLaptopCode,
+    title: 'Languages & Core',
+    items: [
+      'Java, Python, C, C++, JavaScript / TypeScript',
+      'Linux 개발 환경, Syscall 및 인터럽트 이해',
+    ],
+  },
+  {
+    icon: FaRobot,
+    title: 'AI & Data',
+    items: [
+      'Python (PyTorch, TensorFlow) 모델 학습 및 추론',
+      'OpenCV 영상 전처리 & OpenVINO 최적화',
+      'PyTorch → ONNX → HEF 변환 (Edge AI 가속기 적용)',
+      'MLOps 기반 모델 CI/CD 파이프라인 구축',
+    ],
+  },
+  {
+    icon: FaMicrochip,
+    title: 'Embedded & Hardware',
+    items: [
+      'RFID ↔ Raspberry Pi 5 간 SPI 통신',
+      '드라이버 API 활용 카메라 동작/출력 설정',
+    ],
+  },
+  {
+    icon: FaServer,
+    title: 'Web & DevOps',
+    items: [
+      'NestJS, Next.js, Spring, React 활용',
+      'REST API 설계 및 JSON 기반 HTTP 통신',
+      'Docker (Dockerfile, Compose) 컨테이너 배포',
+      'GitHub Actions CI/CD & Branch Protection',
+    ],
+  },
+]
+
+export default skills


### PR DESCRIPTION
## 관련 이슈
closes #111
Jira: FRONT-42

## 변경 유형
- [x] Refactor

## 변경 내용

### 신규 파일 (`lib/data/`)
| 파일 | 타입 | 설명 |
|---|---|---|
| `experience.ts` | `ExperienceItem` | `id, period, role, org, desc, url?` |
| `education.ts` | `EducationItem` | `id, period, course, org, desc, url?` |
| `skills.ts` | `SkillCategory` | `icon, title, items[]` |

### 컴포넌트 변경
- `Experience.tsx`, `Education.tsx`, `Skills.tsx`: 인라인 데이터 배열 제거 → `lib/data` import
- `Experience.tsx`, `Education.tsx`: `url` 필드가 있을 때 기관명을 외부 링크로 렌더링 (선택적 확장)

### 앞으로 데이터 수정 방법
```ts
// lib/data/experience.ts 만 편집
const experiences: ExperienceItem[] = [
  { id: 2, period: '...', role: '...', org: '...', desc: '...', url: 'https://...' },
]
```

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 에러 없음
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거