### PR TITLE
FRONT-43: feat: 동적 sitemap.xml + robots.txt 생성

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://hsm9411.vercel.app'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/auth/', '/debug/'],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,59 @@
+import type { MetadataRoute } from 'next'
+import { fetchPosts, fetchProjects } from '@/lib/api/server'
+import type { Post } from '@/lib/api/posts'
+import type { Project } from '@/lib/api/projects'
+
+export const revalidate = 3600
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://hsm9411.vercel.app'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/projects`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/blog`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+  ]
+
+  const [postRoutes, projectRoutes] = await Promise.all([
+    fetchPosts({ page: 1, limit: 1000 })
+      .then((data: { items: Post[] }) =>
+        data.items
+          .filter((post) => post.isPublished)
+          .map((post): MetadataRoute.Sitemap[number] => ({
+            url: `${BASE_URL}/blog/${post.id}`,
+            lastModified: new Date(post.updatedAt),
+            changeFrequency: 'weekly',
+            priority: 0.7,
+          }))
+      )
+      .catch(() => [] as MetadataRoute.Sitemap),
+
+    fetchProjects({ page: 1, limit: 1000 })
+      .then((data: { items: Project[] }) =>
+        data.items.map((project): MetadataRoute.Sitemap[number] => ({
+          url: `${BASE_URL}/projects/${project.id}`,
+          lastModified: new Date(project.updatedAt),
+          changeFrequency: 'monthly',
+          priority: 0.8,
+        }))
+      )
+      .catch(() => [] as MetadataRoute.Sitemap),
+  ])
+
+  return [...staticRoutes, ...postRoutes, ...projectRoutes]
+}


### PR DESCRIPTION
## 관련 이슈
closes #113
Jira: FRONT-43

## 변경 유형
- [x] New feature

## 변경 내용

### `app/sitemap.ts`
- Next.js App Router `MetadataRoute.Sitemap` 활용
- **정적 라우트**: `/`(priority 1.0), `/projects`(0.9), `/blog`(0.9)
- **동적 라우트**:
  - `/blog/[id]`: `isPublished` 필터, `updatedAt` 기준 `lastModified`, priority 0.7
  - `/projects/[id]`: 전체 포함, `updatedAt` 기준 `lastModified`, priority 0.8
- `revalidate = 3600` (1h ISR, 기존 전략 동일)
- API 오류 시 정적 라우트만 반환 — 빌드/배포 실패 방지

### `app/robots.ts`
- 전체 크롤링 허용, `/api/` `/auth/` `/debug/` 차단
- `sitemap` 필드에 sitemap URL 자동 포함

### 환경변수 추가 필요
Vercel 대시보드에 `NEXT_PUBLIC_SITE_URL` 추가:
```
NEXT_PUBLIC_SITE_URL=https://{실제-도메인}
```

## 체크리스트
- [x] 빌드 시 `/sitemap.xml`, `/robots.txt` 라우트 정상 생성 확인
- [x] 빌드 에러 없음
- [x] 콘솔 에러 없음