### PR TITLE
fix: 모바일 프로젝트 카드 패딩 축소

### DIFF
--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -118,7 +118,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="mx-auto max-w-[1000px] px-5 py-10">
+      <div className="mx-auto max-w-[1000px] px-4 py-8 sm:px-5 sm:py-10">
 
         <div className="mb-8 flex items-start justify-between">
           <div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -70,7 +70,7 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
       </div>
 
       {/* 콘텐츠 — 각 영역 고정 높이로 카드 크기 통일 */}
-      <div className="flex flex-col p-5">
+      <div className="flex flex-col p-4 sm:p-5">
 
         {/* 상태 배지 — h-[22px] 고정 */}
         <div className="mb-2.5 flex h-[22px] items-center">


### PR DESCRIPTION
## 관련 이슈
모바일에서 ProjectCard 콘텐츠 패딩이 커서 답답해 보이는 문제 수정

## 변경 유형
- [x] Bug fix

## 변경 내용
- `ProjectCard` 콘텐츠 영역: `p-5` → `p-4 sm:p-5`
- `ProjectsClient` 컨테이너: `px-5 py-10` → `px-4 py-8 sm:px-5 sm:py-10`

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 확인
- [x] 콘솔 에러 없음