### PR TITLE
FRONT-46: feat: 모바일 댓글·체인지로그 UI 경량화

### DIFF
--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -197,36 +197,38 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
         </div>
       ) : (
         <>
-          <div className="space-y-3">
+          <div>
             {comments.map((comment) => (
               <div
                 key={comment.id}
-                className="rounded-xl border border-gray-100 bg-gray-50 p-4 dark:border-gray-700/50 dark:bg-gray-900"
+                className="border-b border-gray-100 py-4 last:border-b-0 dark:border-gray-800"
               >
-                <div className="mb-2 flex items-center justify-between">
-                  <div className="flex items-center gap-2">
+                <div className="mb-2 flex items-start justify-between gap-3">
+                  <div className="flex min-w-0 items-center gap-2">
                     {/* 아바타 이니셜 */}
-                    <div className="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-500 text-xs font-bold text-white">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-500 text-xs font-bold text-white">
                       {comment.user.nickname.charAt(0).toUpperCase()}
                     </div>
-                    <span className="text-sm font-semibold text-gray-900 dark:text-white">
-                      {comment.user.nickname}
-                    </span>
-                    {comment.isAnonymous && (
-                      <span className="rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-500 dark:bg-gray-700 dark:text-gray-400">
-                        익명
+                    <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                      <span className="text-sm font-semibold text-gray-900 dark:text-white">
+                        {comment.user.nickname}
                       </span>
-                    )}
+                      {comment.isAnonymous && (
+                        <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                          익명
+                        </span>
+                      )}
+                      <span className="text-xs text-gray-400 dark:text-gray-500">
+                        · {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
+                      </span>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs text-gray-400 dark:text-gray-500">
-                      {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
-                    </span>
+                  <div className="flex shrink-0 items-center gap-1">
                     {comment.isMine && editingId !== comment.id && (
                       <button
                         type="button"
                         onClick={() => handleEditStart(comment)}
-                        className="rounded p-0.5 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
+                        className="rounded p-1 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
                         aria-label="댓글 수정"
                       >
                         <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -238,7 +240,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                       <button
                         type="button"
                         onClick={() => setDeleteTargetId(comment.id)}
-                        className="rounded p-0.5 text-gray-300 transition-colors hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400"
+                        className="rounded p-1 text-gray-300 transition-colors hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400"
                         aria-label="댓글 삭제"
                       >
                         <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -249,7 +251,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                   </div>
                 </div>
                 {editingId === comment.id ? (
-                  <div className="pl-9">
+                  <div>
                     <textarea
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
@@ -280,7 +282,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                     </div>
                   </div>
                 ) : (
-                  <p className="whitespace-pre-wrap pl-9 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+                  <p className="whitespace-pre-wrap text-sm leading-relaxed text-gray-700 dark:text-gray-300">
                     {comment.content}
                   </p>
                 )}

--- a/components/UpdateTimeline.tsx
+++ b/components/UpdateTimeline.tsx
@@ -132,7 +132,7 @@ export default function UpdateTimeline({ projectId }: Props) {
   const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-blue-500'
 
   return (
-    <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:p-8">
+    <section className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:p-8">
       {/* 헤더 */}
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -223,7 +223,7 @@ export default function UpdateTimeline({ projectId }: Props) {
       ) : (
         <ol className="relative border-l border-gray-200 dark:border-gray-700">
           {updates.map((item) => (
-            <li key={item.id} className="mb-8 ml-4 last:mb-0">
+            <li key={item.id} className="mb-5 ml-4 last:mb-0 sm:mb-8">
               {/* 타임라인 점 */}
               <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-white bg-blue-500 dark:border-gray-800 dark:bg-blue-400" />
 


### PR DESCRIPTION
## 관련 이슈
closes #121
Jira: FRONT-46

## 변경 유형
- [x] New feature (UX 개선)

## 변경 내용

### CommentSection — 박스형 → 라인 구분형
- 댓글 카드 `border + bg-gray-50 + rounded-xl` 제거 → `border-b` 라인 구분
- 닉네임 · 시간을 한 줄에 compact 배치 (`·` separator)
- `pl-9` 인덴트 제거로 모바일에서 텍스트 전체 너비 활용

### UpdateTimeline — 모바일 패딩 축소
- 섹션 `p-6` → `p-4 sm:p-8`
- 아이템 간격 `mb-8` → `mb-5 sm:mb-8`

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 댓글 수정/삭제 기능 정상
- [x] 다크모드 정상
- [x] 빌드 성공 확인
- [x] 콘솔 에러 없음