### PR TITLE
FRONT-47: fix: 모바일 ProjectCard 썸네일 비율 축소 및 고정 높이 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,161 @@
 # portfolio-frontend
 
-Next.js 기반 포트폴리오 & 기술 블로그 프론트엔드.  
-Vercel에 배포되며, `portfolio-backend` (NestJS / Oracle Cloud)와 REST API로 통신한다.
+개인 포트폴리오 & 기술 블로그 프론트엔드.  
+Next.js App Router 기반으로 구성되어 있으며, Vercel에 배포됩니다.  
+백엔드(`portfolio-backend` — NestJS / Oracle Cloud)와 REST API로 통신합니다.
+
+---
+
+## 주요 기능
+
+### 블로그
+- 게시글 목록 — 카테고리 필터, 키워드 검색(debounce), 정렬(최신순·조회수·좋아요순)
+- 게시글 상세 — Markdown 렌더링(코드 하이라이팅), 읽기 진행바, 목차(TOC, sticky)
+- 좋아요 / 댓글 CRUD (페이지네이션 더보기)
+- 공유 버튼 (URL 복사 / Web Share API)
+- 관리자 전용 작성·수정·삭제
+
+### 프로젝트
+- 프로젝트 목록 — 상태 필터(전체·진행중·완료·보관), 기술 스택 태그 클릭 필터, 키워드 검색, 정렬
+- 프로젝트 상세 — 이미지 갤러리(라이트박스), Changelog 타임라인, 좋아요 / 댓글
+- devicon 기반 썸네일 플레이스홀더 (이미지 없을 때 기술 스택 아이콘 자동 표시)
+- 관리자 전용 작성·수정·삭제
+
+### 홈
+- 히어로 섹션, 프로젝트 미리보기, 블로그 미리보기
+- Skills / Experience / Education / Contact(EmailJS) 섹션
+
+### 공통
+- Supabase OAuth 인증 (Google · GitHub · Kakao)
+- 다크모드 지원
+- 동적 `sitemap.xml` + `robots.txt` (Next.js Metadata API)
+- SEO — 페이지별 메타데이터, OG/Twitter Card
+- Vercel Analytics
+- 스켈레톤 로딩 UI
+- Toast 알림 / ConfirmDialog
 
 ---
 
 ## 기술 스택
 
-| 영역 | 기술 |
+| 분류 | 기술 |
 |------|------|
 | Framework | Next.js 16 (App Router) |
 | Language | TypeScript 5 |
-| Styling | Tailwind CSS v4 |
-| Auth | Supabase Auth (`@supabase/ssr`) |
+| Styling | Tailwind CSS 4 |
+| Auth | Supabase Auth (`@supabase/ssr`) — Google / GitHub / Kakao OAuth |
 | HTTP | Axios (모듈 레벨 토큰 관리) |
-| Markdown | react-markdown + remark-gfm |
+| Markdown | react-markdown + remark-gfm + rehype-highlight |
+| Date | date-fns |
 | Mail | EmailJS (`@emailjs/browser`) |
+| Analytics | @vercel/analytics |
 | Deploy | Vercel |
+| CI | GitHub Actions (PR 시 lint + build) |
 
 ---
 
-## 프로젝트 구조
+## 디렉토리 구조
 
 ```
 app/
-├── page.tsx              # 홈 (SSR — 프로젝트·포스트 병렬 fetch)
-├── blog/                 # 블로그 목록 / 상세 / 작성 / 수정
-├── projects/             # 프로젝트 목록 / 상세 / 작성 / 수정
-├── auth/                 # OAuth 콜백 처리
-├── login/                # 로그인 페이지
-├── debug/                # 개발용 디버그 페이지
-└── globals.css           # 전역 스타일 (Tailwind + .markdown-body)
+├── page.tsx                  # 홈 (SSR — 프로젝트·포스트 병렬 fetch)
+├── layout.tsx                # 루트 레이아웃 (Navbar, 테마 Provider)
+├── error.tsx                 # 루트 Error Boundary
+├── not-found.tsx             # 404 페이지
+├── sitemap.ts                # 동적 sitemap.xml (ISR 1h)
+├── robots.ts                 # robots.txt
+├── blog/
+│   ├── page.tsx              # 블로그 목록 (SSR + CSR)
+│   ├── BlogClient.tsx        # 검색·필터·정렬 CSR 클라이언트
+│   ├── [id]/                 # 블로그 상세 (SSR + 클라이언트 컴포넌트)
+│   └── new/                  # 게시글 작성 (관리자)
+├── projects/
+│   ├── page.tsx              # 프로젝트 목록 (SSR + CSR)
+│   ├── ProjectsClient.tsx    # 검색·필터·정렬 CSR 클라이언트
+│   ├── [id]/                 # 프로젝트 상세 (SSR + 클라이언트 컴포넌트)
+│   └── new/                  # 프로젝트 작성 (관리자)
+├── auth/callback/            # Supabase OAuth 콜백
+├── login/                    # 로그인 페이지
+├── api/[...path]/            # 백엔드 API 프록시 라우트
+├── api/revalidate/           # ISR 수동 재검증 엔드포인트
+└── debug/                    # 개발 전용 디버그 페이지
 
 components/
-├── Navbar.tsx            # 글로벌 Navbar (sticky, 스크롤 blur, 모바일 사이드 패널)
-├── PostCard.tsx          # 블로그 카드 (썸네일 + 메타)
-├── ProjectCard.tsx       # 프로젝트 카드 (썸네일 / devicon 플레이스홀더)
-├── Skills.tsx            # Skills 섹션
-├── Experience.tsx        # 경력 섹션
-├── Education.tsx         # 교육 섹션
-├── Contact.tsx           # EmailJS 문의 폼
-├── AuthButton.tsx        # 로그인/로그아웃 버튼
-├── LikeButton.tsx        # 좋아요 버튼 (클라이언트)
-├── CommentSection.tsx    # 댓글 섹션 (클라이언트)
-└── ...
+├── Navbar.tsx                # 글로벌 Navbar (sticky, 스크롤 blur, 모바일 사이드 패널)
+├── PostCard.tsx              # 블로그 카드
+├── ProjectCard.tsx           # 프로젝트 카드 (썸네일 / devicon 플레이스홀더, 기술 스택 클릭 필터)
+├── CommentSection.tsx        # 댓글 섹션 (CRUD + 페이지네이션)
+├── LikeButton.tsx            # 좋아요 버튼
+├── UpdateTimeline.tsx        # 프로젝트 Changelog 타임라인
+├── ImageGallery.tsx          # 이미지 갤러리 + 라이트박스
+├── ImageGalleryUploader.tsx  # 이미지 업로드 UI
+├── EditorBar.tsx             # 게시글·프로젝트 에디터 공통 sticky 바
+├── TechStackInput.tsx        # 기술 스택 태그 입력
+├── ThumbnailUploader.tsx     # 썸네일 업로드
+├── Skills.tsx                # 기술 스택 섹션
+├── Experience.tsx            # 경력 섹션
+├── Education.tsx             # 교육 섹션
+├── Contact.tsx               # EmailJS 문의 폼
+├── AuthButton.tsx            # 로그인/로그아웃 버튼
+└── ui/
+    ├── FormField.tsx         # label 래퍼 (required 지원)
+    ├── Spinner.tsx           # 전체화면 로딩 스피너
+    ├── ErrorAlert.tsx        # 에러 알림 박스
+    ├── Toast.tsx             # 토스트 알림
+    ├── ConfirmDialog.tsx     # 삭제 확인 다이얼로그
+    ├── PostCardSkeleton.tsx  # 블로그 카드 스켈레톤
+    └── ProjectCardSkeleton.tsx  # 프로젝트 카드 스켈레톤
 
 lib/
 ├── api/
-│   ├── client.ts         # Axios 인스턴스 (모듈 레벨 토큰 store)
-│   ├── server.ts         # 서버 컴포넌트용 fetch 함수
-│   ├── posts.ts          # 포스트 API
-│   ├── projects.ts       # 프로젝트 API
-│   ├── comments.ts       # 댓글 API
-│   └── likes.ts          # 좋아요 API
-├── supabase/             # Supabase 클라이언트 (client / server)
-├── types/                # 공통 타입 정의
-└── utils/                # 유틸 함수 (devicon 등)
+│   ├── client.ts            # Axios 인스턴스 (모듈 레벨 토큰 store)
+│   ├── server.ts            # 서버 컴포넌트용 fetch 유틸
+│   ├── posts.ts             # 블로그 포스트 API
+│   ├── projects.ts          # 프로젝트 API
+│   ├── comments.ts          # 댓글 API
+│   ├── likes.ts             # 좋아요 API
+│   └── updates.ts           # 프로젝트 Changelog API
+├── data/
+│   ├── skills.ts            # 기술 스택 정적 데이터
+│   ├── experience.ts        # 경력 정적 데이터
+│   └── education.ts         # 교육 정적 데이터
+├── supabase/
+│   ├── client.ts            # 브라우저용 Supabase 클라이언트
+│   └── server.ts            # 서버용 Supabase 클라이언트
+├── styles/
+│   └── form.ts              # inputClass 공통 Tailwind 클래스
+├── types/
+│   └── api.ts               # 공용 타입 정의
+└── utils/
+    └── devicon.ts           # 기술 스택 → devicon URL 매핑
 
 hooks/
-├── useAuth.ts            # 인증 상태 + isAdmin 판단
-└── useTheme.ts           # 다크모드 토글
+├── useAuth.ts               # Supabase 세션 구독 + isAdmin 판단
+├── useTheme.ts              # 다크/라이트 모드 토글
+├── useDebounce.ts           # 검색 debounce
+├── useToast.ts              # 토스트 알림 상태 관리
+└── useUnsavedWarning.ts     # 폼 이탈 방지 경고
 ```
+
+---
+
+## 렌더링 전략
+
+| 페이지 | 전략 | 비고 |
+|--------|------|------|
+| `/` (홈) | SSR | 프로젝트·포스트 병렬 fetch, SEO |
+| `/blog` | SSR + CSR hybrid | 초기 데이터 SSR, 검색·필터·정렬 CSR |
+| `/projects` | SSR + CSR hybrid | 초기 데이터 SSR, 필터·정렬 CSR |
+| `/blog/[id]` | SSR | 본문 SEO, 좋아요·댓글은 클라이언트 컴포넌트 |
+| `/projects/[id]` | SSR | 동일 |
+| `/sitemap.xml` | ISR (1h) | 동적 생성, 블로그·프로젝트 URL 포함 |
 
 ---
 
 ## 인증 흐름
 
 ```
-브라우저 → Supabase Auth (OAuth: Google / GitHub)
+브라우저 → Supabase Auth (OAuth: Google / GitHub / Kakao)
               ↓ session
          onAuthStateChange → setAccessToken(session.access_token)
               ↓ (모듈 레벨 변수)
@@ -78,18 +166,7 @@ hooks/
 
 - 매 요청마다 `getSession()` 비동기 호출 없이 동기적으로 토큰 참조 (병목 제거)
 - 401 응답 + Authorization 헤더가 있었던 경우에만 강제 로그아웃 처리
-
----
-
-## 렌더링 전략
-
-| 페이지 | 전략 | 이유 |
-|--------|------|------|
-| `/` (홈) | SSR | 프로젝트·포스트 병렬 fetch, SEO |
-| `/blog` | SSR + CSR hybrid | 초기 데이터 SSR, 검색·페이지네이션 CSR |
-| `/projects` | SSR + CSR hybrid | 초기 데이터 SSR, 상태 필터 CSR |
-| `/blog/[id]` | SSR (서버컴포넌트 fetch) | 본문 SEO, 좋아요·댓글은 클라이언트 |
-| `/projects/[id]` | SSR | 동일 |
+- 관리자 판단: 세션 이메일이 `NEXT_PUBLIC_ADMIN_EMAILS` 목록에 포함된 경우
 
 ---
 
@@ -98,12 +175,21 @@ hooks/
 `.env.local` 기준:
 
 ```env
-NEXT_PUBLIC_API_URL=https://<backend-domain>
 NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
+
+NEXT_PUBLIC_API_URL=https://<prod-backend-domain>
+NEXT_PUBLIC_API_URL_DEV=https://<dev-backend-domain>
+
+NEXT_PUBLIC_ADMIN_EMAILS=email1@example.com,email2@example.com
+
+NEXT_PUBLIC_SITE_URL=https://<your-vercel-domain>
+
 NEXT_PUBLIC_EMAILJS_SERVICE_ID=<service-id>
 NEXT_PUBLIC_EMAILJS_TEMPLATE_ID=<template-id>
 NEXT_PUBLIC_EMAILJS_PUBLIC_KEY=<public-key>
+
+REVALIDATE_SECRET=<secret>  # ISR 수동 재검증용 (서버 전용, NEXT_PUBLIC_ 아님)
 ```
 
 ---
@@ -112,8 +198,10 @@ NEXT_PUBLIC_EMAILJS_PUBLIC_KEY=<public-key>
 
 ```bash
 npm install
-npm run dev       # http://localhost:3000
-npm run build     # 프로덕션 빌드 검증
+cp .env.example .env.local   # 환경변수 설정
+npm run dev                   # http://localhost:3000
+npm run build                 # 프로덕션 빌드 검증
+npm run lint                  # ESLint
 ```
 
 ---
@@ -124,34 +212,30 @@ Git 연동 자동 배포:
 
 | 브랜치 | 배포 대상 |
 |--------|-----------|
-| `main` | Production (`https://hsm9411.vercel.app` 또는 커스텀 도메인) |
+| `main` | Production |
 | `develop` | Preview URL (Vercel 자동 생성) |
 
-`vercel.json`:
-```json
-{
-  "buildCommand": "npm run build"
-}
-```
-
 환경변수는 Vercel 대시보드 → **Settings > Environment Variables** 에서 관리.  
-`NEXT_PUBLIC_*` 변수는 Production / Preview / Development 환경에 모두 등록해야 빌드가 정상 동작한다.
+`REVALIDATE_SECRET`은 Vercel에서 **Sensitive** 타입으로 등록 (값 노출 방지).
 
 ---
 
 ## 브랜치 전략
 
 ```
-main        → Production 배포 (Vercel)
-develop     → Preview 배포 (Vercel) — 기능 개발 기본 브랜치
-feature/*   → 기능 단위 개발 → develop PR
+main        → Production 배포
+  └── develop     → Preview 배포, 통합 브랜치
+        └── FRONT-N-이슈설명   → 기능·수정·리팩토링 단위 작업 브랜치
 ```
+
+- feature → develop: **squash merge**
+- develop → main: **regular merge** (릴리즈 단위)
 
 ---
 
-## 모바일 반응형 기준
+## 모바일 반응형
 
-Tailwind 브레이크포인트 기준:
+Tailwind 브레이크포인트 기준 **모바일 퍼스트** 설계:
 
 | prefix | 범위 | 비고 |
 |--------|------|------|
@@ -159,12 +243,3 @@ Tailwind 브레이크포인트 기준:
 | `sm:` | 640px~ | 태블릿 세로 |
 | `md:` | 768px~ | 태블릿 가로 / 소형 데스크탑 |
 | `lg:` | 1024px~ | 데스크탑 |
-
-설계 원칙: **모바일 퍼스트** — 기본값을 모바일 기준으로 작성하고 `sm:` / `md:`로 확장.
-
-주요 적용 지점:
-- 섹션 패딩: `py-12 md:py-20`
-- 카드 내부 패딩: `p-4 sm:p-6 md:p-8`
-- 제목: `text-2xl md:text-3xl` / `text-3xl sm:text-4xl md:text-5xl`
-- PostCard 썸네일: `w-[110px] sm:w-[150px] md:w-[170px]`
-- `.markdown-body`: 모바일 `0.9375rem`, `sm:` 이상 `1rem`으로 미디어쿼리 분기

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -25,8 +25,8 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
   return (
     <div className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
 
-      {/* 썸네일 */}
-      <div className="relative aspect-video w-full overflow-hidden bg-gray-100 dark:bg-gray-700">
+      {/* 썸네일 — 모바일에서 2:1 비율로 축소, sm 이상에서 16:9 */}
+      <div className="relative aspect-[2/1] w-full overflow-hidden bg-gray-100 sm:aspect-video dark:bg-gray-700">
         {project.thumbnailUrl ? (
           <Image
             src={project.thumbnailUrl}
@@ -79,13 +79,13 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
           </span>
         </div>
 
-        {/* 제목 — 최대 2줄, 16px × 1.4 × 2 = 44.8px → h-[46px] (여유 1px) */}
-        <h3 className="mb-2 line-clamp-2 h-[46px] overflow-hidden text-base font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400">
+        {/* 제목 — 최대 2줄. sm 이상 다열 그리드에서만 고정 높이로 행 정렬 */}
+        <h3 className="mb-2 line-clamp-2 overflow-hidden text-base font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400 sm:h-[46px]">
           {project.title}
         </h3>
 
-        {/* 요약 — 최대 3줄, line-height 1.5 기준 h-[63px] */}
-        <p className="mb-3.5 line-clamp-3 h-[63px] text-sm leading-[1.5] text-gray-500 dark:text-gray-400">
+        {/* 요약 — 최대 3줄. sm 이상 다열 그리드에서만 고정 높이로 행 정렬 */}
+        <p className="mb-3.5 line-clamp-3 text-sm leading-[1.5] text-gray-500 dark:text-gray-400 sm:h-[63px]">
           {project.summary}
         </p>
 


### PR DESCRIPTION
## 관련 이슈
closes #124
Jira: FRONT-47

## 변경 유형
- [x] Bug fix

## 변경 내용

### 문제
모바일(375px) 1열 레이아웃에서 ProjectCard가 너무 많은 세로 공간을 점유하고 있었음.
- `aspect-video`(16:9) 썸네일 → 모바일 전체 너비에서 약 210px 높이
- `h-[46px]`, `h-[63px]` 고정 높이 → 다열 그리드 정렬용이지만 1열에서는 불필요한 여백/잘림 발생

### 해결
- 썸네일: `aspect-[2/1] sm:aspect-video` — 모바일에서 2:1 비율로 축소, sm 이상은 기존 16:9 유지
- 제목: `h-[46px]` → `sm:h-[46px]` — 모바일 1열에서 자연 높이, sm 이상 그리드 정렬 유지
- 요약: `h-[63px]` → `sm:h-[63px]` — 동일

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거