### PR TITLE
FRONT-48: feat: 모바일 필터 pills 가로 스크롤 개선

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -131,14 +131,14 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
           )}
         </div>
 
-        {/* 카테고리 필터 */}
-        <div className="mb-5 flex flex-wrap gap-2">
+        {/* 카테고리 필터 — 모바일 가로 스크롤 */}
+        <div className="scrollbar-hide mb-5 flex gap-2 overflow-x-auto">
           {CATEGORIES.map(({ value, label }) => (
             <button
               key={value}
               type="button"
               onClick={() => updateUrl(1, searchFromUrl, value, sortFromUrl)}
-              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+              className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
                 categoryFromUrl === value
                   ? 'bg-blue-600 text-white'
                   : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'

--- a/app/globals.css
+++ b/app/globals.css
@@ -32,6 +32,15 @@ body {
   transition: background-color 0.3s, color 0.3s;
 }
 
+/* 스크롤바 숨김 유틸 */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* ─────────────────────────────────────────────
    Markdown Body — prose 플러그인 없이 직접 정의
    @tailwindcss/typography 호환성 이슈 우회

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -185,13 +185,13 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
           )}
         </div>
 
-        {/* 상태 필터 */}
-        <div className="mb-4 flex flex-wrap gap-2">
+        {/* 상태 필터 — 모바일 가로 스크롤 */}
+        <div className="scrollbar-hide mb-4 flex gap-2 overflow-x-auto">
           {STATUS_FILTERS.map((f) => (
             <button
               key={f.value}
               onClick={() => handleStatusChange(f.value)}
-              className={`rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors ${
+              className={`shrink-0 rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors ${
                 statusFromUrl === f.value
                   ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
                   : 'bg-white text-gray-500 ring-1 ring-inset ring-gray-200 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-700 dark:hover:bg-gray-700'


### PR DESCRIPTION
## 관련 이슈
closes #126
Jira: FRONT-48

## 변경 유형
- [x] New feature

## 변경 내용

### 문제
블로그/프로젝트 목록의 카테고리·상태 필터 pills가 `flex-wrap`으로 줄바꿈되어 모바일에서 2행 이상 차지함.

### 해결
- `flex flex-wrap` → `flex overflow-x-auto` + 각 버튼에 `shrink-0`
- `.scrollbar-hide` CSS 유틸 추가 (`globals.css`) — 스크롤바 숨김 처리
- 적용: `BlogClient.tsx` 카테고리 필터 / `ProjectsClient.tsx` 상태 필터

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거