### PR TITLE
FRONT-49: feat: 홈 히어로 섹션 모바일 높이 축소 및 CTA 버튼 추가

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ export default async function Home() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
 
       {/* ── 히어로 ── */}
-      <section className="flex min-h-[calc(100vh-72px)] items-center justify-center border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+      <section className="flex min-h-[75vh] items-center justify-center border-b border-gray-200 bg-white sm:min-h-[calc(100vh-72px)] dark:border-gray-800 dark:bg-gray-900">
         <div className="mx-auto flex w-full max-w-[900px] flex-col items-center gap-8 px-5 pb-8 pt-8 md:flex-row md:items-center md:justify-between md:gap-16 md:pb-[5vh]">
           <div className="text-center md:text-left">
             <h1 className="mb-4 text-3xl font-black leading-tight tracking-tight text-gray-900 dark:text-white sm:text-4xl md:text-5xl">
@@ -50,6 +50,24 @@ export default async function Home() {
               또한, 효율적인 <strong className="font-semibold text-gray-800 dark:text-gray-200">협업</strong>을 위해 필요한 툴과 기술,<br className="hidden sm:block" />
               그리고 <strong className="font-semibold text-gray-800 dark:text-gray-200">개발 프로세스 체계</strong>를 경험하며 성장하고 있습니다.
             </p>
+            {/* CTA 버튼 */}
+            <div className="mt-6 flex flex-wrap justify-center gap-3 sm:mt-7 md:justify-start">
+              <Link
+                href="/projects"
+                className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+              >
+                프로젝트 보기
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+              <Link
+                href="/blog"
+                className="flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:bg-transparent dark:text-gray-200 dark:hover:bg-gray-800"
+              >
+                블로그 보기
+              </Link>
+            </div>
           </div>
           <div className="shrink-0">
             <img

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -141,7 +141,7 @@ export default function Navbar() {
       <button
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         aria-label="맨 위로"
-        className={`fixed bottom-8 right-8 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all duration-300 hover:border-gray-300 hover:text-gray-600 hover:shadow-md dark:border-gray-700 dark:bg-gray-900 dark:text-gray-500 dark:hover:border-gray-500 dark:hover:text-gray-300 ${
+        className={`fixed bottom-5 right-4 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all duration-300 hover:border-gray-300 hover:text-gray-600 hover:shadow-md sm:bottom-8 sm:right-8 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-500 dark:hover:border-gray-500 dark:hover:text-gray-300 ${
           showScrollTop ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3 pointer-events-none'
         }`}
       >


### PR DESCRIPTION
## 관련 이슈
closes #128
Jira: FRONT-49

## 변경 유형
- [x] New feature

## 변경 내용

### `app/page.tsx` — 히어로 섹션
- 높이: `min-h-[calc(100vh-72px)]` → `min-h-[75vh] sm:min-h-[calc(100vh-72px)]`
  - 모바일에서 뷰포트 75%만 점유, 아래 Skills 섹션이 살짝 보여 스크롤 유도
  - sm 이상은 기존 전체 높이 유지
- CTA 버튼 2개 추가 (설명 텍스트 아래)
  - "프로젝트 보기 →" (blue filled) → `/projects`
  - "블로그 보기" (outline) → `/blog`
  - 모바일 중앙 정렬, md 이상 좌측 정렬

### `components/Navbar.tsx` — 스크롤 탑 버튼
- `bottom-8 right-8` → `bottom-5 right-4 sm:bottom-8 sm:right-8`
- 모바일 엄지 도달 영역(하단 좌·우 코너 인접)으로 개선

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거