### PR TITLE
FRONT-50: feat: 히어로 CTA 모바일 전용 노출 및 스타일 개선

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,22 +50,25 @@ export default async function Home() {
               또한, 효율적인 <strong className="font-semibold text-gray-800 dark:text-gray-200">협업</strong>을 위해 필요한 툴과 기술,<br className="hidden sm:block" />
               그리고 <strong className="font-semibold text-gray-800 dark:text-gray-200">개발 프로세스 체계</strong>를 경험하며 성장하고 있습니다.
             </p>
-            {/* CTA 버튼 */}
-            <div className="mt-6 flex flex-wrap justify-center gap-3 sm:mt-7 md:justify-start">
+            {/* CTA — 모바일 전용 (데스크탑은 네비바로 충분) */}
+            <div className="mt-6 flex items-center justify-center gap-4 sm:hidden">
               <Link
                 href="/projects"
-                className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+                className="flex items-center gap-1.5 rounded-lg border border-gray-800 px-4 py-2 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50 dark:border-gray-300 dark:text-gray-100 dark:hover:bg-gray-800"
               >
                 프로젝트 보기
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                 </svg>
               </Link>
               <Link
                 href="/blog"
-                className="flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:bg-transparent dark:text-gray-200 dark:hover:bg-gray-800"
+                className="flex items-center gap-1 text-sm font-medium text-gray-400 transition-colors hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
               >
-                블로그 보기
+                블로그
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
               </Link>
             </div>
           </div>
@@ -73,7 +76,7 @@ export default async function Home() {
             <img
               src="/profile.png"
               alt="Profile"
-              className="w-[180px] h-auto border border-gray-200 object-cover shadow-[12px_12px_0px_rgba(0,0,0,0.1)] dark:border-gray-700 dark:shadow-[12px_12px_0px_rgba(255,255,255,0.05)] sm:w-[210px] md:w-[240px] md:shadow-[15px_15px_0px_rgba(0,0,0,0.1)]"
+              className="h-auto w-[150px] border border-gray-200 object-cover shadow-[12px_12px_0px_rgba(0,0,0,0.1)] dark:border-gray-700 dark:shadow-[12px_12px_0px_rgba(255,255,255,0.05)] sm:w-[210px] md:w-[240px] md:shadow-[15px_15px_0px_rgba(0,0,0,0.1)]"
             />
           </div>
         </div>


### PR DESCRIPTION
## 관련 이슈
closes #130
Jira: FRONT-50

## 변경 유형
- [x] New feature

## 변경 내용

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| CTA 노출 범위 | 전체 (모바일 + 데스크탑) | `sm:hidden` — 모바일 전용 |
| 프로젝트 버튼 스타일 | `bg-blue-600` filled | `border-gray-800` outline |
| 블로그 버튼 스타일 | outline | text-only + 화살표 |
| 프로필 이미지 | `w-[180px]` | `w-[150px] sm:w-[210px]` |

### 판단 근거
- 데스크탑: 네비바에 Projects/Blog 링크 항상 노출 → CTA 중복, 제거
- 모바일: 네비바가 햄버거 뒤에 숨어 있어 CTA가 실질적 역할 → 유지
- 이미지 30px 축소: 모바일 히어로 총 높이 감소 → Skills 섹션 일부 노출

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거