### PR TITLE
FRONT-52: refactor: 모바일 카드/간격 세련도 개선

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -111,7 +111,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="mx-auto max-w-[1000px] px-5 py-10">
+      <div className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-10">
 
         <div className="mb-8 flex items-start justify-between">
           <div>
@@ -222,7 +222,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
           </div>
         ) : (
           <>
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3 sm:gap-4">
               {posts.map((post) => (
                 <Link key={post.id} href={`/blog/${post.id}?from=list`} className="block">
                   <PostCard post={post} />

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -255,7 +255,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
           </div>
         ) : (
           <>
-            <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid gap-3 sm:grid-cols-2 sm:gap-5 lg:grid-cols-3">
               {projects.map((project) => (
                 <Link key={project.id} href={`/projects/${project.id}?from=list`} className="block">
                   <ProjectCard project={project} onTechClick={handleTechClick} />

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -21,7 +21,7 @@ export default function PostCard({ post }: PostCardProps) {
   const readTime = post.readingTime ?? calcReadTime(post.content)
 
   return (
-    <article className="group flex overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
+    <article className="group flex overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
 
       {/* 텍스트 영역 */}
       <div className="flex min-w-0 flex-1 flex-col py-3.5 pl-4 pr-3 sm:py-4 sm:pl-5 sm:pr-4">
@@ -80,7 +80,7 @@ export default function PostCard({ post }: PostCardProps) {
 
       {/* 썸네일 — 모바일에서 너비 축소, 없으면 영역 없음 */}
       {post.thumbnailUrl && (
-        <div className="relative w-[110px] shrink-0 self-stretch sm:w-[150px] md:w-[170px]">
+        <div className="relative w-[88px] shrink-0 self-stretch sm:w-[130px] md:w-[160px]">
           <Image
             src={post.thumbnailUrl}
             alt={post.title}


### PR DESCRIPTION
## 관련 이슈
closes #135
Jira: FRONT-52

## 변경 유형
- [x] Refactor / UI 개선

## 변경 내용

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| BlogClient 모바일 패딩 | `py-10` (40px 고정) | `py-6 sm:py-10` |
| BlogClient 카드 간격 | `gap-4` | `gap-3 sm:gap-4` |
| PostCard border-radius | `rounded-xl` | `rounded-2xl` |
| PostCard 썸네일 너비 | `w-[110px]` | `w-[88px] sm:w-[130px]` |
| ProjectsClient 카드 간격 | `gap-5` | `gap-3 sm:gap-5` |

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 (`npm run build`)
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거