### PR TITLE
FRONT-53: feat: PostCard 모바일 세로 스택 레이아웃 전환

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -21,10 +21,10 @@ export default function PostCard({ post }: PostCardProps) {
   const readTime = post.readingTime ?? calcReadTime(post.content)
 
   return (
-    <article className="group flex overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
+    <article className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600 sm:flex-row">
 
       {/* 텍스트 영역 */}
-      <div className="flex min-w-0 flex-1 flex-col py-3.5 pl-4 pr-3 sm:py-4 sm:pl-5 sm:pr-4">
+      <div className="flex min-w-0 flex-1 flex-col p-4 sm:py-4 sm:pl-5 sm:pr-4">
 
         {/* 카테고리 + 태그 */}
         <div className="flex items-center gap-1.5 overflow-hidden">
@@ -78,14 +78,14 @@ export default function PostCard({ post }: PostCardProps) {
         </div>
       </div>
 
-      {/* 썸네일 — 모바일에서 너비 축소, 없으면 영역 없음 */}
+      {/* 썸네일 — 모바일: 상단 전체 너비(2:1), sm+: 오른쪽 사이드 */}
       {post.thumbnailUrl && (
-        <div className="relative w-[88px] shrink-0 self-stretch sm:w-[130px] md:w-[160px]">
+        <div className="relative aspect-[2/1] w-full shrink-0 overflow-hidden sm:order-last sm:aspect-auto sm:w-[130px] sm:self-stretch md:w-[160px]">
           <Image
             src={post.thumbnailUrl}
             alt={post.title}
             fill
-            sizes="170px"
+            sizes="(max-width: 640px) 100vw, 160px"
             className="object-cover"
           />
         </div>


### PR DESCRIPTION
## 관련 이슈
closes #137
Jira: FRONT-53

## 변경 유형
- [x] Feature / UI 개선

## 변경 내용

| 화면 | 변경 전 | 변경 후 |
|---|---|---|
| 모바일 (< 640px) | 가로 배치 — 텍스트 왼쪽 + 88px 썸네일 오른쪽 `self-stretch` | 세로 스택 — 이미지 상단 전체 너비(`aspect-[2/1]`), 텍스트 아래 |
| sm+ (640px+) | 가로 배치 유지 | 동일 (오른쪽 사이드 썸네일 `sm:order-last`) |

Medium, Dev.to, Hashnode 등 주요 블로그 플랫폼의 표준 모바일 카드 패턴과 동일.

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 성공 (`npm run build`)
- [x] 썸네일 없는 카드도 정상 표시 확인
- [x] 콘솔 에러 없음