### PR TITLE
FRONT-54: feat: 히어로 모바일 레이아웃 개선 및 Teal 컬러 시스템 적용

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -141,7 +141,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
               className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
                 categoryFromUrl === value
                   ? 'bg-indigo-600 text-white'
-                  : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                  : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700'
               }`}
             >
               {label}
@@ -154,7 +154,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             <select
               value={sortFromUrl}
               onChange={(e) => updateUrl(1, searchFromUrl, categoryFromUrl, e.target.value)}
-              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300"
             >
               {SORT_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
@@ -175,11 +175,11 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder="제목 또는 내용으로 검색..."
-                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-indigo-500"
+                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-indigo-500"
               />
             </div>
             {(searchInput || searchFromUrl) && (
-              <button type="button" onClick={handleClear} className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700">
+              <button type="button" onClick={handleClear} className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400 dark:hover:bg-gray-700">
                 초기화
               </button>
             )}
@@ -198,7 +198,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             ))}
           </div>
         ) : posts.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-gray-200 py-24 text-center dark:border-gray-700">
+          <div className="rounded-2xl border border-dashed border-gray-200 py-24 text-center dark:border-zinc-700">
             <p className="text-sm text-gray-400 dark:text-gray-500">
               {searchFromUrl
                 ? `"${searchFromUrl}"에 대한 결과가 없습니다.`
@@ -214,7 +214,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             {(searchFromUrl || categoryFromUrl) && (
               <button
                 onClick={() => { setSearchInput(''); updateUrl(1, '', '', sortFromUrl) }}
-                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-400"
+                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-400"
               >
                 전체 목록으로
               </button>
@@ -235,7 +235,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                 <button
                   onClick={() => updateUrl(Math.max(1, pageFromUrl - 1), searchFromUrl, categoryFromUrl, sortFromUrl)}
                   disabled={pageFromUrl === 1}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -247,7 +247,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                 <button
                   onClick={() => updateUrl(Math.min(totalPages, pageFromUrl + 1), searchFromUrl, categoryFromUrl, sortFromUrl)}
                   disabled={pageFromUrl === totalPages}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />

--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -121,7 +121,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
           {isAdmin && (
             <Link
               href="/blog/new"
-              className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+              className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
@@ -140,7 +140,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
               onClick={() => updateUrl(1, searchFromUrl, value, sortFromUrl)}
               className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
                 categoryFromUrl === value
-                  ? 'bg-blue-600 text-white'
+                  ? 'bg-teal-600 text-white'
                   : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
               }`}
             >
@@ -154,7 +154,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             <select
               value={sortFromUrl}
               onChange={(e) => updateUrl(1, searchFromUrl, categoryFromUrl, e.target.value)}
-              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
             >
               {SORT_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
@@ -163,7 +163,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             <div className="relative flex-1">
               {loading && searchInput ? (
                 <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-blue-500" />
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-teal-500" />
                 </div>
               ) : (
                 <svg className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -175,7 +175,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder="제목 또는 내용으로 검색..."
-                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-blue-500"
+                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-teal-500"
               />
             </div>
             {(searchInput || searchFromUrl) && (
@@ -207,7 +207,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                   : '포스트가 없습니다.'}
             </p>
             {isAdmin && !searchFromUrl && !categoryFromUrl && (
-              <Link href="/blog/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">
+              <Link href="/blog/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-700">
                 첫 포스트 작성하기
               </Link>
             )}

--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -110,7 +110,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
   ]
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
       <div className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-10">
 
         <div className="mb-8 flex items-start justify-between">
@@ -121,7 +121,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
           {isAdmin && (
             <Link
               href="/blog/new"
-              className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
+              className="flex items-center gap-1.5 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-700"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
@@ -140,8 +140,8 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
               onClick={() => updateUrl(1, searchFromUrl, value, sortFromUrl)}
               className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
                 categoryFromUrl === value
-                  ? 'bg-teal-600 text-white'
-                  : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                  ? 'bg-indigo-600 text-white'
+                  : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
               }`}
             >
               {label}
@@ -154,7 +154,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             <select
               value={sortFromUrl}
               onChange={(e) => updateUrl(1, searchFromUrl, categoryFromUrl, e.target.value)}
-              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
             >
               {SORT_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
@@ -163,7 +163,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
             <div className="relative flex-1">
               {loading && searchInput ? (
                 <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-teal-500" />
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-indigo-500" />
                 </div>
               ) : (
                 <svg className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -175,11 +175,11 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder="제목 또는 내용으로 검색..."
-                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-teal-500"
+                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-indigo-500"
               />
             </div>
             {(searchInput || searchFromUrl) && (
-              <button type="button" onClick={handleClear} className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700">
+              <button type="button" onClick={handleClear} className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700">
                 초기화
               </button>
             )}
@@ -207,14 +207,14 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                   : '포스트가 없습니다.'}
             </p>
             {isAdmin && !searchFromUrl && !categoryFromUrl && (
-              <Link href="/blog/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-700">
+              <Link href="/blog/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700">
                 첫 포스트 작성하기
               </Link>
             )}
             {(searchFromUrl || categoryFromUrl) && (
               <button
                 onClick={() => { setSearchInput(''); updateUrl(1, '', '', sortFromUrl) }}
-                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400"
+                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-400"
               >
                 전체 목록으로
               </button>
@@ -235,7 +235,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                 <button
                   onClick={() => updateUrl(Math.max(1, pageFromUrl - 1), searchFromUrl, categoryFromUrl, sortFromUrl)}
                   disabled={pageFromUrl === 1}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -247,7 +247,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
                 <button
                   onClick={() => updateUrl(Math.min(totalPages, pageFromUrl + 1), searchFromUrl, categoryFromUrl, sortFromUrl)}
                   disabled={pageFromUrl === totalPages}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />

--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -141,7 +141,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
               className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
                 categoryFromUrl === value
                   ? 'bg-indigo-600 text-white'
-                  : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                  : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700'
               }`}
             >
               {label}
@@ -179,7 +179,7 @@ export default function BlogClient({ initialData }: { initialData: InitialData }
               />
             </div>
             {(searchInput || searchFromUrl) && (
-              <button type="button" onClick={handleClear} className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400 dark:hover:bg-gray-700">
+              <button type="button" onClick={handleClear} className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400 dark:hover:bg-zinc-700">
                 초기화
               </button>
             )}

--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -117,7 +117,7 @@ export default function BlogPostClient({ post, from }: Props) {
       {/* 삭제 확인 모달 */}
       {showDeleteConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 backdrop-blur-sm">
-          <div className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl dark:bg-gray-800 sm:p-6">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl dark:bg-zinc-800 sm:p-6">
             <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30 sm:h-12 sm:w-12">
               <svg className="h-5 w-5 text-red-600 dark:text-red-400 sm:h-6 sm:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -128,7 +128,7 @@ export default function BlogPostClient({ post, from }: Props) {
               <span className="font-medium text-gray-900 dark:text-white">{'"'}{post.title}{'"'}</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="flex gap-2.5 sm:gap-3">
-              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm">취소</button>
+              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm">취소</button>
               <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60 sm:py-2.5 sm:text-sm">
                 {deleting ? (
                   <span className="flex items-center justify-center gap-1.5">
@@ -143,7 +143,7 @@ export default function BlogPostClient({ post, from }: Props) {
       )}
 
       {/* 헤더 */}
-      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
+      <header className="border-b border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-800/50">
         <div className="mx-auto max-w-[1000px] px-4 pt-5 pb-6 sm:px-5 sm:pt-7 sm:pb-10">
           {/* 뒤로가기 + 공유 + 관리자 액션 */}
           <div className="mb-5 flex items-center justify-between sm:mb-6">
@@ -162,7 +162,7 @@ export default function BlogPostClient({ post, from }: Props) {
                 className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium shadow-sm transition-colors ${
                   copied
                     ? 'border-green-200 bg-green-50 text-green-600 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400'
-                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700'
                 }`}
               >
                 {copied ? (
@@ -185,7 +185,7 @@ export default function BlogPostClient({ post, from }: Props) {
                 <>
                   <button
                     onClick={() => router.push(`/blog/${post.id}/edit`)}
-                    className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                    className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
                   >
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -194,7 +194,7 @@ export default function BlogPostClient({ post, from }: Props) {
                   </button>
                   <button
                     onClick={() => setShowDeleteConfirm(true)}
-                    className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                    className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-zinc-800 dark:text-red-400 dark:hover:bg-red-900/20"
                   >
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -243,7 +243,7 @@ export default function BlogPostClient({ post, from }: Props) {
         <aside className="hidden min-[1440px]:block fixed top-36 w-48"
           style={{ left: 'calc(50% + 520px)' }}
         >
-          <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
             <p className="mb-3 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
               <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h10M4 14h12M4 18h8" />
@@ -273,7 +273,7 @@ export default function BlogPostClient({ post, from }: Props) {
         <button
           onClick={() => setTocSheetOpen(true)}
           aria-label="목차 열기"
-          className="sm:hidden fixed bottom-5 left-4 z-40 flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3.5 py-2 text-xs font-semibold text-gray-600 shadow-md transition-colors hover:border-gray-300 hover:text-gray-800 dark:border-gray-700 dark:bg-zinc-900 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-gray-200"
+          className="sm:hidden fixed bottom-5 left-4 z-40 flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3.5 py-2 text-xs font-semibold text-gray-600 shadow-md transition-colors hover:border-gray-300 hover:text-gray-800 dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-400 dark:hover:border-zinc-500 dark:hover:text-gray-200"
         >
           <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h10M4 14h12M4 18h8" />
@@ -293,7 +293,7 @@ export default function BlogPostClient({ post, from }: Props) {
           <div
             className={`sm:hidden fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-white shadow-2xl transition-transform duration-300 ease-in-out dark:bg-zinc-900 ${tocSheetOpen ? 'translate-y-0' : 'translate-y-full'}`}
           >
-            <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+            <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-zinc-800">
               <span className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
                 <svg className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h10M4 14h12M4 18h8" />
@@ -303,7 +303,7 @@ export default function BlogPostClient({ post, from }: Props) {
               <button
                 onClick={() => setTocSheetOpen(false)}
                 aria-label="목차 닫기"
-                className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+                className="rounded-lg p-1.5 text-gray-400 hover:bg-zinc-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-zinc-800 dark:hover:text-gray-300"
               >
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -336,7 +336,7 @@ export default function BlogPostClient({ post, from }: Props) {
 
           {/* 태블릿 TOC 아코디언 (640px~1440px) */}
           {tocItems.length > 0 && (
-            <div className="hidden sm:block min-[1440px]:hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="hidden sm:block min-[1440px]:hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
               <button
                 onClick={() => setTocOpen((v) => !v)}
                 className="flex w-full items-center justify-between px-4 py-3.5 text-sm font-semibold text-gray-700 dark:text-gray-200"
@@ -352,7 +352,7 @@ export default function BlogPostClient({ post, from }: Props) {
                 </svg>
               </button>
               {tocOpen && (
-                <nav className="border-t border-gray-100 px-4 py-3 dark:border-gray-700">
+                <nav className="border-t border-gray-100 px-4 py-3 dark:border-zinc-700">
                   <ul className="space-y-1.5">
                     {tocItems.map((item) => (
                       <li key={item.id} className={item.level === 3 ? 'ml-4' : ''}>
@@ -371,7 +371,7 @@ export default function BlogPostClient({ post, from }: Props) {
             </div>
           )}
 
-          <section className="-mx-4 bg-white px-4 py-6 dark:bg-gray-800 sm:mx-0 sm:rounded-2xl sm:border sm:border-gray-200 sm:px-6 sm:py-10 sm:shadow-sm dark:sm:border-gray-700 md:px-10 md:py-12">
+          <section className="-mx-4 bg-white px-4 py-6 dark:bg-zinc-800 sm:mx-0 sm:rounded-2xl sm:border sm:border-gray-200 sm:px-6 sm:py-10 sm:shadow-sm dark:sm:border-gray-700 md:px-10 md:py-12">
             <div className="markdown-body">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
@@ -383,10 +383,10 @@ export default function BlogPostClient({ post, from }: Props) {
             </div>
           </section>
 
-          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-6">
+          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-5 shadow-sm dark:border-zinc-700 dark:bg-zinc-800 sm:px-6">
             <LikeButton targetType="post" targetId={post.id} initialLikeCount={post.likeCount} />
           </div>
-          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:px-6 sm:py-8 md:px-8">
+          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800 sm:px-6 sm:py-8 md:px-8">
             <CommentSection targetType="post" targetId={post.id} />
           </div>
         </div>

--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -104,12 +104,12 @@ export default function BlogPostClient({ post, from }: Props) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
 
       {/* 읽기 진행바 */}
       <div className="fixed left-0 top-0 z-50 h-[3px] w-full bg-transparent">
         <div
-          className="h-full bg-teal-500 transition-[width] duration-100 ease-out dark:bg-teal-400"
+          className="h-full bg-indigo-500 transition-[width] duration-100 ease-out dark:bg-indigo-400"
           style={{ width: `${readingProgress}%` }}
         />
       </div>
@@ -128,7 +128,7 @@ export default function BlogPostClient({ post, from }: Props) {
               <span className="font-medium text-gray-900 dark:text-white">{'"'}{post.title}{'"'}</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="flex gap-2.5 sm:gap-3">
-              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm">취소</button>
+              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm">취소</button>
               <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60 sm:py-2.5 sm:text-sm">
                 {deleting ? (
                   <span className="flex items-center justify-center gap-1.5">
@@ -162,7 +162,7 @@ export default function BlogPostClient({ post, from }: Props) {
                 className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium shadow-sm transition-colors ${
                   copied
                     ? 'border-green-200 bg-green-50 text-green-600 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400'
-                    : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
                 }`}
               >
                 {copied ? (
@@ -185,7 +185,7 @@ export default function BlogPostClient({ post, from }: Props) {
                 <>
                   <button
                     onClick={() => router.push(`/blog/${post.id}/edit`)}
-                    className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                    className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
                   >
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -209,7 +209,7 @@ export default function BlogPostClient({ post, from }: Props) {
           {post.tags.length > 0 && (
             <div className="mb-4 flex flex-wrap gap-1.5 sm:mb-5 sm:gap-2">
               {post.tags.map((tag) => (
-                <span key={tag} className="rounded-md bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300 dark:ring-teal-500/30 sm:px-2.5 sm:py-1 sm:text-xs">#{tag}</span>
+                <span key={tag} className="rounded-md bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold text-indigo-700 ring-1 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-300 dark:ring-indigo-500/30 sm:px-2.5 sm:py-1 sm:text-xs">#{tag}</span>
               ))}
             </div>
           )}
@@ -256,7 +256,7 @@ export default function BlogPostClient({ post, from }: Props) {
                   <li key={item.id} className={item.level === 3 ? 'ml-3' : ''}>
                     <a
                       href={`#${item.id}`}
-                      className="block truncate text-sm text-gray-600 hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
+                      className="block truncate text-sm text-gray-600 hover:text-indigo-600 dark:text-gray-400 dark:hover:text-indigo-400"
                     >
                       {item.text}
                     </a>
@@ -273,7 +273,7 @@ export default function BlogPostClient({ post, from }: Props) {
         <button
           onClick={() => setTocSheetOpen(true)}
           aria-label="목차 열기"
-          className="sm:hidden fixed bottom-5 left-4 z-40 flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3.5 py-2 text-xs font-semibold text-gray-600 shadow-md transition-colors hover:border-gray-300 hover:text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-gray-200"
+          className="sm:hidden fixed bottom-5 left-4 z-40 flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3.5 py-2 text-xs font-semibold text-gray-600 shadow-md transition-colors hover:border-gray-300 hover:text-gray-800 dark:border-gray-700 dark:bg-zinc-900 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-gray-200"
         >
           <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h10M4 14h12M4 18h8" />
@@ -291,7 +291,7 @@ export default function BlogPostClient({ post, from }: Props) {
             aria-hidden="true"
           />
           <div
-            className={`sm:hidden fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-white shadow-2xl transition-transform duration-300 ease-in-out dark:bg-gray-900 ${tocSheetOpen ? 'translate-y-0' : 'translate-y-full'}`}
+            className={`sm:hidden fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-white shadow-2xl transition-transform duration-300 ease-in-out dark:bg-zinc-900 ${tocSheetOpen ? 'translate-y-0' : 'translate-y-full'}`}
           >
             <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
               <span className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
@@ -317,7 +317,7 @@ export default function BlogPostClient({ post, from }: Props) {
                     <a
                       href={`#${item.id}`}
                       onClick={() => setTocSheetOpen(false)}
-                      className="block py-0.5 text-sm text-gray-600 transition-colors hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
+                      className="block py-0.5 text-sm text-gray-600 transition-colors hover:text-indigo-600 dark:text-gray-400 dark:hover:text-indigo-400"
                     >
                       {item.text}
                     </a>
@@ -359,7 +359,7 @@ export default function BlogPostClient({ post, from }: Props) {
                         <a
                           href={`#${item.id}`}
                           onClick={() => setTocOpen(false)}
-                          className="block truncate text-sm text-gray-600 hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
+                          className="block truncate text-sm text-gray-600 hover:text-indigo-600 dark:text-gray-400 dark:hover:text-indigo-400"
                         >
                           {item.text}
                         </a>

--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
@@ -109,7 +109,7 @@ export default function BlogPostClient({ post, from }: Props) {
       {/* 읽기 진행바 */}
       <div className="fixed left-0 top-0 z-50 h-[3px] w-full bg-transparent">
         <div
-          className="h-full bg-blue-500 transition-[width] duration-100 ease-out dark:bg-blue-400"
+          className="h-full bg-teal-500 transition-[width] duration-100 ease-out dark:bg-teal-400"
           style={{ width: `${readingProgress}%` }}
         />
       </div>
@@ -209,7 +209,7 @@ export default function BlogPostClient({ post, from }: Props) {
           {post.tags.length > 0 && (
             <div className="mb-4 flex flex-wrap gap-1.5 sm:mb-5 sm:gap-2">
               {post.tags.map((tag) => (
-                <span key={tag} className="rounded-md bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30 sm:px-2.5 sm:py-1 sm:text-xs">#{tag}</span>
+                <span key={tag} className="rounded-md bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300 dark:ring-teal-500/30 sm:px-2.5 sm:py-1 sm:text-xs">#{tag}</span>
               ))}
             </div>
           )}
@@ -256,7 +256,7 @@ export default function BlogPostClient({ post, from }: Props) {
                   <li key={item.id} className={item.level === 3 ? 'ml-3' : ''}>
                     <a
                       href={`#${item.id}`}
-                      className="block truncate text-sm text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+                      className="block truncate text-sm text-gray-600 hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
                     >
                       {item.text}
                     </a>
@@ -317,7 +317,7 @@ export default function BlogPostClient({ post, from }: Props) {
                     <a
                       href={`#${item.id}`}
                       onClick={() => setTocSheetOpen(false)}
-                      className="block py-0.5 text-sm text-gray-600 transition-colors hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+                      className="block py-0.5 text-sm text-gray-600 transition-colors hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
                     >
                       {item.text}
                     </a>
@@ -359,7 +359,7 @@ export default function BlogPostClient({ post, from }: Props) {
                         <a
                           href={`#${item.id}`}
                           onClick={() => setTocOpen(false)}
-                          className="block truncate text-sm text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+                          className="block truncate text-sm text-gray-600 hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
                         >
                           {item.text}
                         </a>

--- a/app/blog/[id]/BlogPostClient.tsx
+++ b/app/blog/[id]/BlogPostClient.tsx
@@ -128,7 +128,7 @@ export default function BlogPostClient({ post, from }: Props) {
               <span className="font-medium text-gray-900 dark:text-white">{'"'}{post.title}{'"'}</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="flex gap-2.5 sm:gap-3">
-              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm">취소</button>
+              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-zinc-700 sm:py-2.5 sm:text-sm">취소</button>
               <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60 sm:py-2.5 sm:text-sm">
                 {deleting ? (
                   <span className="flex items-center justify-center gap-1.5">
@@ -162,7 +162,7 @@ export default function BlogPostClient({ post, from }: Props) {
                 className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium shadow-sm transition-colors ${
                   copied
                     ? 'border-green-200 bg-green-50 text-green-600 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400'
-                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700'
                 }`}
               >
                 {copied ? (
@@ -185,7 +185,7 @@ export default function BlogPostClient({ post, from }: Props) {
                 <>
                   <button
                     onClick={() => router.push(`/blog/${post.id}/edit`)}
-                    className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                    className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700"
                   >
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -371,7 +371,7 @@ export default function BlogPostClient({ post, from }: Props) {
             </div>
           )}
 
-          <section className="-mx-4 bg-white px-4 py-6 dark:bg-zinc-800 sm:mx-0 sm:rounded-2xl sm:border sm:border-gray-200 sm:px-6 sm:py-10 sm:shadow-sm dark:sm:border-gray-700 md:px-10 md:py-12">
+          <section className="-mx-4 bg-white px-4 py-6 dark:bg-zinc-800 sm:mx-0 sm:rounded-2xl sm:border sm:border-gray-200 sm:px-6 sm:py-10 sm:shadow-sm dark:sm:border-zinc-700 md:px-10 md:py-12">
             <div className="markdown-body">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}

--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -141,7 +141,7 @@ export default function EditPostPage() {
 
         {!preview ? (
           <form id="edit-post-form" onSubmit={handleSubmit}>
-            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-800 sm:p-8">
 
               {/* 기본 정보 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기본 정보</p>
@@ -190,7 +190,7 @@ export default function EditPostPage() {
                 />
               </FormField>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 본문 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">본문 (Markdown)</p>
@@ -209,7 +209,7 @@ export default function EditPostPage() {
             </div>
           </form>
         ) : (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800 sm:p-12">
+          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-zinc-700 dark:bg-zinc-800 sm:p-12">
             {formData.tags.length > 0 && (
               <div className="mb-5 flex flex-wrap gap-2">
                 {formData.tags.map((tag) => (

--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
@@ -213,7 +213,7 @@ export default function EditPostPage() {
             {formData.tags.length > 0 && (
               <div className="mb-5 flex flex-wrap gap-2">
                 {formData.tags.map((tag) => (
-                  <span key={tag} className="rounded-md bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300">
+                  <span key={tag} className="rounded-md bg-teal-50 px-2.5 py-1 text-xs font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300">
                     #{tag}
                   </span>
                 ))}

--- a/app/blog/[id]/edit/page.tsx
+++ b/app/blog/[id]/edit/page.tsx
@@ -114,7 +114,7 @@ export default function EditPostPage() {
   if (!isAdmin) return null
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
       <ConfirmDialog
         open={showCancelConfirm}
         title="수정 취소"
@@ -213,7 +213,7 @@ export default function EditPostPage() {
             {formData.tags.length > 0 && (
               <div className="mb-5 flex flex-wrap gap-2">
                 {formData.tags.map((tag) => (
-                  <span key={tag} className="rounded-md bg-teal-50 px-2.5 py-1 text-xs font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300">
+                  <span key={tag} className="rounded-md bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-300">
                     #{tag}
                   </span>
                 ))}

--- a/app/blog/error.tsx
+++ b/app/blog/error.tsx
@@ -38,7 +38,7 @@ export default function BlogError({ error, reset }: Props) {
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             홈으로
           </Link>

--- a/app/blog/error.tsx
+++ b/app/blog/error.tsx
@@ -38,7 +38,7 @@ export default function BlogError({ error, reset }: Props) {
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700"
           >
             홈으로
           </Link>

--- a/app/blog/error.tsx
+++ b/app/blog/error.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useEffect } from 'react'
 import Link from 'next/link'
@@ -32,7 +32,7 @@ export default function BlogError({ error, reset }: Props) {
         <div className="flex justify-center gap-3">
           <button
             onClick={reset}
-            className="rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+            className="rounded-xl bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
           >
             다시 시도
           </button>

--- a/app/blog/error.tsx
+++ b/app/blog/error.tsx
@@ -14,7 +14,7 @@ export default function BlogError({ error, reset }: Props) {
   }, [error])
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 dark:bg-zinc-900">
       <div className="w-full max-w-md text-center">
         <div className="mb-6 flex justify-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
@@ -32,13 +32,13 @@ export default function BlogError({ error, reset }: Props) {
         <div className="flex justify-center gap-3">
           <button
             onClick={reset}
-            className="rounded-xl bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
+            className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-700"
           >
             다시 시도
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             홈으로
           </Link>

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -89,7 +89,7 @@ export default function NewPostPage() {
   if (!authReady || !isAdmin) return <Spinner />
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
       <ConfirmDialog
         open={showCancelConfirm}
         title="작성 취소"
@@ -189,7 +189,7 @@ export default function NewPostPage() {
             {formData.tags.length > 0 && (
               <div className="mb-5 flex flex-wrap gap-2">
                 {formData.tags.map((tag) => (
-                  <span key={tag} className="rounded-md bg-teal-50 px-2.5 py-1 text-xs font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300">
+                  <span key={tag} className="rounded-md bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-300">
                     #{tag}
                   </span>
                 ))}

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -117,7 +117,7 @@ export default function NewPostPage() {
 
         {!preview ? (
           <form id="new-post-form" onSubmit={handleSubmit}>
-            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-800 sm:p-8">
 
               {/* 기본 정보 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기본 정보</p>
@@ -166,7 +166,7 @@ export default function NewPostPage() {
                 />
               </FormField>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 본문 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">본문 (Markdown)</p>
@@ -185,7 +185,7 @@ export default function NewPostPage() {
             </div>
           </form>
         ) : (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800 sm:p-12">
+          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-zinc-700 dark:bg-zinc-800 sm:p-12">
             {formData.tags.length > 0 && (
               <div className="mb-5 flex flex-wrap gap-2">
                 {formData.tags.map((tag) => (

--- a/app/blog/new/page.tsx
+++ b/app/blog/new/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
@@ -189,7 +189,7 @@ export default function NewPostPage() {
             {formData.tags.length > 0 && (
               <div className="mb-5 flex flex-wrap gap-2">
                 {formData.tags.map((tag) => (
-                  <span key={tag} className="rounded-md bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300">
+                  <span key={tag} className="rounded-md bg-teal-50 px-2.5 py-1 text-xs font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300">
                     #{tag}
                   </span>
                 ))}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+﻿import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import { fetchPosts } from '@/lib/api/server'
 import BlogClient from './BlogClient'
@@ -25,7 +25,7 @@ export default async function BlogPage() {
   return (
     <Suspense fallback={
       <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-blue-600" />
+        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-teal-600" />
       </div>
     }>
       <BlogClient initialData={initialData} />

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -24,8 +24,8 @@ export default async function BlogPage() {
 
   return (
     <Suspense fallback={
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-teal-600" />
+      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
+        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-indigo-600" />
       </div>
     }>
       <BlogClient initialData={initialData} />

--- a/app/debug/page.tsx
+++ b/app/debug/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState } from 'react'
 import type { Session } from '@supabase/supabase-js'
@@ -90,7 +90,7 @@ export default function DebugPage() {
         <div className="mb-8 flex flex-wrap gap-4">
           <button
             onClick={checkSession}
-            className="rounded-lg bg-blue-600 px-6 py-3 text-white hover:bg-blue-700"
+            className="rounded-lg bg-teal-600 px-6 py-3 text-white hover:bg-teal-700"
           >
             세션 확인
           </button>
@@ -167,9 +167,9 @@ export default function DebugPage() {
         </div>
 
         {/* 안내 */}
-        <div className="mt-8 rounded-lg border-l-4 border-blue-500 bg-blue-50 p-6">
-          <h3 className="mb-2 font-bold text-blue-900">💡 사용 방법</h3>
-          <ol className="list-inside list-decimal space-y-1 text-sm text-blue-800">
+        <div className="mt-8 rounded-lg border-l-4 border-teal-500 bg-teal-50 p-6">
+          <h3 className="mb-2 font-bold text-teal-900">💡 사용 방법</h3>
+          <ol className="list-inside list-decimal space-y-1 text-sm text-teal-800">
             <li>먼저 {'"'}세션 확인{'"'} 버튼으로 로그인 상태 확인</li>
             <li>{'"'}Public API 테스트{'"'}로 인증 없이 작동하는 API 테스트</li>
             <li>{'"'}인증 API 테스트{'"'}로 관리자 권한이 필요한 API 테스트</li>

--- a/app/debug/page.tsx
+++ b/app/debug/page.tsx
@@ -82,7 +82,7 @@ export default function DebugPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <div className="min-h-screen bg-zinc-50 p-8">
       <div className="mx-auto max-w-6xl">
         <h1 className="mb-8 text-3xl font-bold">🔍 디버그 페이지</h1>
 
@@ -90,7 +90,7 @@ export default function DebugPage() {
         <div className="mb-8 flex flex-wrap gap-4">
           <button
             onClick={checkSession}
-            className="rounded-lg bg-teal-600 px-6 py-3 text-white hover:bg-teal-700"
+            className="rounded-lg bg-indigo-600 px-6 py-3 text-white hover:bg-indigo-700"
           >
             세션 확인
           </button>
@@ -167,9 +167,9 @@ export default function DebugPage() {
         </div>
 
         {/* 안내 */}
-        <div className="mt-8 rounded-lg border-l-4 border-teal-500 bg-teal-50 p-6">
-          <h3 className="mb-2 font-bold text-teal-900">💡 사용 방법</h3>
-          <ol className="list-inside list-decimal space-y-1 text-sm text-teal-800">
+        <div className="mt-8 rounded-lg border-l-4 border-indigo-500 bg-indigo-50 p-6">
+          <h3 className="mb-2 font-bold text-indigo-900">💡 사용 방법</h3>
+          <ol className="list-inside list-decimal space-y-1 text-sm text-indigo-800">
             <li>먼저 {'"'}세션 확인{'"'} 버튼으로 로그인 상태 확인</li>
             <li>{'"'}Public API 테스트{'"'}로 인증 없이 작동하는 API 테스트</li>
             <li>{'"'}인증 API 테스트{'"'}로 관리자 권한이 필요한 API 테스트</li>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -14,7 +14,7 @@ export default function GlobalError({ error, reset }: Props) {
   }, [error])
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 dark:bg-zinc-900">
       <div className="w-full max-w-md text-center">
         <div className="mb-6 flex justify-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
@@ -32,13 +32,13 @@ export default function GlobalError({ error, reset }: Props) {
         <div className="flex justify-center gap-3">
           <button
             onClick={reset}
-            className="rounded-xl bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
+            className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-700"
           >
             다시 시도
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             홈으로
           </Link>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useEffect } from 'react'
 import Link from 'next/link'
@@ -32,7 +32,7 @@ export default function GlobalError({ error, reset }: Props) {
         <div className="flex justify-center gap-3">
           <button
             onClick={reset}
-            className="rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+            className="rounded-xl bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
           >
             다시 시도
           </button>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -38,7 +38,7 @@ export default function GlobalError({ error, reset }: Props) {
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             홈으로
           </Link>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -38,7 +38,7 @@ export default function GlobalError({ error, reset }: Props) {
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700"
           >
             홈으로
           </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: #ffffff;
+  --background: #fafaf9;
   --foreground: #171717;
 
   --nav-r: 255; --nav-g: 255; --nav-b: 255;
@@ -95,17 +95,17 @@ body {
 
 /* 링크 */
 .markdown-body a {
-  color: #2563eb;
+  color: #0d9488;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .markdown-body a:hover {
-  color: #1d4ed8;
+  color: #0f766e;
 }
 
 .dark .markdown-body a {
-  color: #60a5fa;
+  color: #2dd4bf;
 }
 
 /* 강조 */
@@ -157,18 +157,18 @@ body {
 
 /* 인용구 */
 .markdown-body blockquote {
-  border-left: 4px solid #3b82f6;
-  background-color: #eff6ff;
-  color: #1e40af;
+  border-left: 4px solid #14b8a6;
+  background-color: #f0fdfa;
+  color: #0f766e;
   margin: 1.5em 0;
   padding: 0.75em 1em;
   border-radius: 0 0.5rem 0.5rem 0;
 }
 
 .dark .markdown-body blockquote {
-  background-color: rgba(59, 130, 246, 0.1);
-  color: #93c5fd;
-  border-left-color: #60a5fa;
+  background-color: rgba(20, 184, 166, 0.1);
+  color: #5eead4;
+  border-left-color: #2dd4bf;
 }
 
 .markdown-body blockquote p {
@@ -219,7 +219,7 @@ body {
 /* 체크박스 리스트 (GFM) */
 .markdown-body input[type="checkbox"] {
   margin-right: 0.5em;
-  accent-color: #2563eb;
+  accent-color: #0d9488;
 }
 
 /* 구분선 */

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: #fafaf9;
+  --background: #fafafa;
   --foreground: #171717;
 
   --nav-r: 255; --nav-g: 255; --nav-b: 255;
@@ -11,7 +11,7 @@
 }
 
 .dark {
-  --background: #111827;
+  --background: #18181b;
   --foreground: #f3f4f6;
 
   --nav-r: 17; --nav-g: 24; --nav-b: 39;
@@ -95,17 +95,17 @@ body {
 
 /* 링크 */
 .markdown-body a {
-  color: #0d9488;
+  color: #4f46e5;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .markdown-body a:hover {
-  color: #0f766e;
+  color: #4338ca;
 }
 
 .dark .markdown-body a {
-  color: #2dd4bf;
+  color: #818cf8;
 }
 
 /* 강조 */
@@ -157,18 +157,18 @@ body {
 
 /* 인용구 */
 .markdown-body blockquote {
-  border-left: 4px solid #14b8a6;
-  background-color: #f0fdfa;
-  color: #0f766e;
+  border-left: 4px solid #6366f1;
+  background-color: #eef2ff;
+  color: #3730a3;
   margin: 1.5em 0;
   padding: 0.75em 1em;
   border-radius: 0 0.5rem 0.5rem 0;
 }
 
 .dark .markdown-body blockquote {
-  background-color: rgba(20, 184, 166, 0.1);
-  color: #5eead4;
-  border-left-color: #2dd4bf;
+  background-color: rgba(99, 102, 241, 0.1);
+  color: #a5b4fc;
+  border-left-color: #818cf8;
 }
 
 .markdown-body blockquote p {
@@ -219,7 +219,7 @@ body {
 /* 체크박스 리스트 (GFM) */
 .markdown-body input[type="checkbox"] {
   margin-right: 0.5em;
-  accent-color: #0d9488;
+  accent-color: #4f46e5;
 }
 
 /* 구분선 */

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -123,7 +123,7 @@ function LoginForm() {
           <button
             onClick={() => handleOAuthLogin('google')}
             type="button"
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 hover:bg-zinc-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 hover:bg-zinc-50 dark:border-gray-600 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             <svg className="h-5 w-5" viewBox="0 0 24 24">
               <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
@@ -137,7 +137,7 @@ function LoginForm() {
           <button
             onClick={() => handleOAuthLogin('github')}
             type="button"
-            className="flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white hover:bg-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600"
+            className="flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white hover:bg-gray-800 dark:bg-zinc-700 dark:hover:bg-gray-600"
           >
             <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
               <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd"/>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect, Suspense } from 'react'
 import { createClient } from '@/lib/supabase/client'
@@ -84,7 +84,7 @@ function LoginForm() {
           </p>
           <Link
             href={redirectUrl}
-            className="mt-4 inline-block text-blue-600 hover:text-blue-700"
+            className="mt-4 inline-block text-teal-600 hover:text-teal-700"
           >
             지금 이동하기 →
           </Link>
@@ -189,7 +189,7 @@ export default function LoginPage() {
   return (
     <Suspense fallback={
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600"></div>
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-teal-600"></div>
       </div>
     }>
       <LoginForm />

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -123,7 +123,7 @@ function LoginForm() {
           <button
             onClick={() => handleOAuthLogin('google')}
             type="button"
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 hover:bg-zinc-50 dark:border-gray-600 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700"
           >
             <svg className="h-5 w-5" viewBox="0 0 24 24">
               <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
@@ -137,7 +137,7 @@ function LoginForm() {
           <button
             onClick={() => handleOAuthLogin('github')}
             type="button"
-            className="flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white hover:bg-gray-800 dark:bg-zinc-700 dark:hover:bg-gray-600"
+            className="flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white hover:bg-gray-800 dark:bg-zinc-700 dark:hover:bg-zinc-600"
           >
             <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
               <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd"/>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -73,7 +73,7 @@ function LoginForm() {
 
   if (isLoggedIn) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+      <div className="flex min-h-screen items-center justify-center bg-zinc-50 px-4 dark:bg-zinc-900">
         <div className="text-center">
           <div className="mb-4 text-6xl">✅</div>
           <h1 className="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
@@ -84,7 +84,7 @@ function LoginForm() {
           </p>
           <Link
             href={redirectUrl}
-            className="mt-4 inline-block text-teal-600 hover:text-teal-700"
+            className="mt-4 inline-block text-indigo-600 hover:text-indigo-700"
           >
             지금 이동하기 →
           </Link>
@@ -94,7 +94,7 @@ function LoginForm() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+    <div className="flex min-h-screen items-center justify-center bg-zinc-50 px-4 dark:bg-zinc-900">
       <div className="w-full max-w-md">
         {/* Header */}
         <div className="mb-8 text-center">
@@ -123,7 +123,7 @@ function LoginForm() {
           <button
             onClick={() => handleOAuthLogin('google')}
             type="button"
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 hover:bg-zinc-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             <svg className="h-5 w-5" viewBox="0 0 24 24">
               <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
@@ -189,7 +189,7 @@ export default function LoginPage() {
   return (
     <Suspense fallback={
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-teal-600"></div>
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600"></div>
       </div>
     }>
       <LoginForm />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,10 +1,10 @@
-import Link from 'next/link'
+﻿import Link from 'next/link'
 
 export default function NotFound() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
       <div className="w-full max-w-md text-center">
-        <p className="mb-2 text-7xl font-extrabold text-blue-600 dark:text-blue-400">404</p>
+        <p className="mb-2 text-7xl font-extrabold text-teal-600 dark:text-teal-400">404</p>
         <h2 className="mb-3 text-xl font-bold text-gray-900 dark:text-white">
           페이지를 찾을 수 없습니다
         </h2>
@@ -13,7 +13,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="inline-block rounded-xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+          className="inline-block rounded-xl bg-teal-600 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
         >
           홈으로 돌아가기
         </Link>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,9 +2,9 @@
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 dark:bg-zinc-900">
       <div className="w-full max-w-md text-center">
-        <p className="mb-2 text-7xl font-extrabold text-teal-600 dark:text-teal-400">404</p>
+        <p className="mb-2 text-7xl font-extrabold text-indigo-600 dark:text-indigo-400">404</p>
         <h2 className="mb-3 text-xl font-bold text-gray-900 dark:text-white">
           페이지를 찾을 수 없습니다
         </h2>
@@ -13,7 +13,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="inline-block rounded-xl bg-teal-600 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
+          className="inline-block rounded-xl bg-indigo-600 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-700"
         >
           홈으로 돌아가기
         </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,8 +34,9 @@ export default async function Home() {
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
 
       {/* ── 히어로 ── */}
-      <section className="flex min-h-[75vh] items-center justify-center border-b border-gray-200 bg-white sm:min-h-[calc(100vh-72px)] dark:border-zinc-800 dark:bg-zinc-900">
-        <div className="mx-auto flex w-full max-w-[900px] flex-col items-center gap-8 px-5 pb-8 pt-8 md:flex-row md:items-center md:justify-between md:gap-16 md:pb-[5vh]">
+      {/* 모바일: py-16 고정 패딩, 사진 숨김 / 데스크탑(md+): 전체 높이 + 사진 우측 */}
+      <section className="flex items-center justify-center border-b border-gray-200 bg-white py-16 sm:py-20 md:min-h-[calc(100vh-72px)] md:py-0 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="mx-auto flex w-full max-w-[900px] flex-col items-center gap-8 px-5 md:flex-row md:items-center md:justify-between md:gap-16 md:pb-[5vh]">
           <div className="text-center md:text-left">
             <h1 className="mb-4 text-3xl font-black leading-tight tracking-tight text-gray-900 dark:text-white sm:text-4xl md:text-5xl">
               안녕하세요,<br />
@@ -51,7 +52,7 @@ export default async function Home() {
               그리고 <strong className="font-semibold text-gray-800 dark:text-gray-200">개발 프로세스 체계</strong>를 경험하며 성장하고 있습니다.
             </p>
             {/* CTA — 모바일 전용 (데스크탑은 네비바로 충분) */}
-            <div className="mt-6 flex items-center justify-center gap-4 sm:hidden">
+            <div className="mt-6 flex items-center justify-center gap-4 md:hidden">
               <Link
                 href="/projects"
                 className="flex items-center gap-1.5 rounded-lg border border-gray-800 px-4 py-2 text-sm font-semibold text-gray-900 transition-colors hover:bg-zinc-50 dark:border-gray-300 dark:text-gray-100 dark:hover:bg-zinc-800"
@@ -72,11 +73,12 @@ export default async function Home() {
               </Link>
             </div>
           </div>
-          <div className="shrink-0">
+          {/* 사진: 모바일에서 숨김, md+ 데스크탑에서만 표시 */}
+          <div className="hidden shrink-0 md:block">
             <img
               src="/profile.png"
               alt="Profile"
-              className="h-auto w-[150px] border border-gray-200 object-cover shadow-[12px_12px_0px_rgba(0,0,0,0.08)] dark:border-zinc-700 dark:shadow-[12px_12px_0px_rgba(255,255,255,0.04)] sm:w-[210px] md:w-[240px] md:shadow-[15px_15px_0px_rgba(0,0,0,0.08)]"
+              className="h-auto w-[240px] border border-gray-200 object-cover shadow-[15px_15px_0px_rgba(0,0,0,0.08)] dark:border-zinc-700 dark:shadow-[15px_15px_0px_rgba(255,255,255,0.04)]"
             />
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default async function Home() {
             </div>
 
             {projectsData.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700 sm:py-14">
+              <div className="rounded-2xl border border-dashed border-gray-200 py-10 text-center dark:border-zinc-700 sm:py-14">
                 <p className="text-sm text-gray-400">아직 프로젝트가 없습니다.</p>
               </div>
             ) : (
@@ -140,7 +140,7 @@ export default async function Home() {
             </div>
 
             {postsData.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700 sm:py-14">
+              <div className="rounded-2xl border border-dashed border-gray-200 py-10 text-center dark:border-zinc-700 sm:py-14">
                 <p className="text-sm text-gray-400">아직 포스트가 없습니다.</p>
               </div>
             ) : (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+﻿import type { Metadata } from 'next'
 import { fetchProjects, fetchPosts } from '@/lib/api/server'
 import { type Project } from '@/lib/api/projects'
 import { type Post } from '@/lib/api/posts'
@@ -31,12 +31,16 @@ export default async function Home() {
   ])
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-stone-50 dark:bg-gray-900">
 
       {/* ── 히어로 ── */}
       <section className="flex min-h-[75vh] items-center justify-center border-b border-gray-200 bg-white sm:min-h-[calc(100vh-72px)] dark:border-gray-800 dark:bg-gray-900">
-        <div className="mx-auto flex w-full max-w-[900px] flex-col items-center gap-8 px-5 pb-8 pt-8 md:flex-row md:items-center md:justify-between md:gap-16 md:pb-[5vh]">
-          <div className="text-center md:text-left">
+        <div className="mx-auto flex w-full max-w-[900px] flex-col-reverse items-start gap-6 px-5 pb-8 pt-8 md:flex-row md:items-center md:justify-between md:gap-16 md:pb-[5vh]">
+          <div className="md:text-left">
+            <span className="mb-4 inline-flex items-center gap-1.5 rounded-full bg-teal-50 px-3 py-1 text-xs font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-950/30 dark:text-teal-400 dark:ring-teal-500/30">
+              <span className="h-1.5 w-1.5 rounded-full bg-teal-500 dark:bg-teal-400" />
+              웹 · 시스템 개발자
+            </span>
             <h1 className="mb-4 text-3xl font-black leading-tight tracking-tight text-gray-900 dark:text-white sm:text-4xl md:text-5xl">
               안녕하세요,<br />
               개발자 하성민입니다.
@@ -51,7 +55,7 @@ export default async function Home() {
               그리고 <strong className="font-semibold text-gray-800 dark:text-gray-200">개발 프로세스 체계</strong>를 경험하며 성장하고 있습니다.
             </p>
             {/* CTA — 모바일 전용 (데스크탑은 네비바로 충분) */}
-            <div className="mt-6 flex items-center justify-center gap-4 sm:hidden">
+            <div className="mt-6 flex items-center gap-4 sm:hidden">
               <Link
                 href="/projects"
                 className="flex items-center gap-1.5 rounded-lg border border-gray-800 px-4 py-2 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50 dark:border-gray-300 dark:text-gray-100 dark:hover:bg-gray-800"
@@ -76,7 +80,7 @@ export default async function Home() {
             <img
               src="/profile.png"
               alt="Profile"
-              className="h-auto w-[150px] border border-gray-200 object-cover shadow-[12px_12px_0px_rgba(0,0,0,0.1)] dark:border-gray-700 dark:shadow-[12px_12px_0px_rgba(255,255,255,0.05)] sm:w-[210px] md:w-[240px] md:shadow-[15px_15px_0px_rgba(0,0,0,0.1)]"
+              className="h-28 w-28 rounded-full border-2 border-gray-200 object-cover shadow-sm dark:border-gray-700 sm:h-36 sm:w-36 md:h-auto md:w-[240px] md:rounded-none md:border md:shadow-[15px_15px_0px_rgba(0,0,0,0.1)]"
             />
           </div>
         </div>
@@ -97,7 +101,7 @@ export default async function Home() {
               </div>
               <Link
                 href="/projects"
-                className="flex items-center gap-1 text-xs font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 sm:text-sm"
+                className="flex items-center gap-1 text-xs font-medium text-teal-600 transition-colors hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300 sm:text-sm"
               >
                 전체보기
                 <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -130,7 +134,7 @@ export default async function Home() {
               </div>
               <Link
                 href="/blog"
-                className="flex items-center gap-1 text-xs font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 sm:text-sm"
+                className="flex items-center gap-1 text-xs font-medium text-teal-600 transition-colors hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300 sm:text-sm"
               >
                 전체보기
                 <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,16 +31,12 @@ export default async function Home() {
   ])
 
   return (
-    <div className="min-h-screen bg-stone-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
 
       {/* ── 히어로 ── */}
-      <section className="flex min-h-[75vh] items-center justify-center border-b border-gray-200 bg-white sm:min-h-[calc(100vh-72px)] dark:border-gray-800 dark:bg-gray-900">
-        <div className="mx-auto flex w-full max-w-[900px] flex-col-reverse items-start gap-6 px-5 pb-8 pt-8 md:flex-row md:items-center md:justify-between md:gap-16 md:pb-[5vh]">
-          <div className="md:text-left">
-            <span className="mb-4 inline-flex items-center gap-1.5 rounded-full bg-teal-50 px-3 py-1 text-xs font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-950/30 dark:text-teal-400 dark:ring-teal-500/30">
-              <span className="h-1.5 w-1.5 rounded-full bg-teal-500 dark:bg-teal-400" />
-              웹 · 시스템 개발자
-            </span>
+      <section className="flex min-h-[75vh] items-center justify-center border-b border-gray-200 bg-white sm:min-h-[calc(100vh-72px)] dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="mx-auto flex w-full max-w-[900px] flex-col items-center gap-8 px-5 pb-8 pt-8 md:flex-row md:items-center md:justify-between md:gap-16 md:pb-[5vh]">
+          <div className="text-center md:text-left">
             <h1 className="mb-4 text-3xl font-black leading-tight tracking-tight text-gray-900 dark:text-white sm:text-4xl md:text-5xl">
               안녕하세요,<br />
               개발자 하성민입니다.
@@ -55,10 +51,10 @@ export default async function Home() {
               그리고 <strong className="font-semibold text-gray-800 dark:text-gray-200">개발 프로세스 체계</strong>를 경험하며 성장하고 있습니다.
             </p>
             {/* CTA — 모바일 전용 (데스크탑은 네비바로 충분) */}
-            <div className="mt-6 flex items-center gap-4 sm:hidden">
+            <div className="mt-6 flex items-center justify-center gap-4 sm:hidden">
               <Link
                 href="/projects"
-                className="flex items-center gap-1.5 rounded-lg border border-gray-800 px-4 py-2 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50 dark:border-gray-300 dark:text-gray-100 dark:hover:bg-gray-800"
+                className="flex items-center gap-1.5 rounded-lg border border-gray-800 px-4 py-2 text-sm font-semibold text-gray-900 transition-colors hover:bg-zinc-50 dark:border-gray-300 dark:text-gray-100 dark:hover:bg-zinc-800"
               >
                 프로젝트 보기
                 <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -80,7 +76,7 @@ export default async function Home() {
             <img
               src="/profile.png"
               alt="Profile"
-              className="h-28 w-28 rounded-full border-2 border-gray-200 object-cover shadow-sm dark:border-gray-700 sm:h-36 sm:w-36 md:h-auto md:w-[240px] md:rounded-none md:border md:shadow-[15px_15px_0px_rgba(0,0,0,0.1)]"
+              className="h-auto w-[150px] border border-gray-200 object-cover shadow-[12px_12px_0px_rgba(0,0,0,0.08)] dark:border-zinc-700 dark:shadow-[12px_12px_0px_rgba(255,255,255,0.04)] sm:w-[210px] md:w-[240px] md:shadow-[15px_15px_0px_rgba(0,0,0,0.08)]"
             />
           </div>
         </div>
@@ -101,7 +97,7 @@ export default async function Home() {
               </div>
               <Link
                 href="/projects"
-                className="flex items-center gap-1 text-xs font-medium text-teal-600 transition-colors hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300 sm:text-sm"
+                className="flex items-center gap-1 text-xs font-medium text-indigo-600 transition-colors hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 sm:text-sm"
               >
                 전체보기
                 <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -134,7 +130,7 @@ export default async function Home() {
               </div>
               <Link
                 href="/blog"
-                className="flex items-center gap-1 text-xs font-medium text-teal-600 transition-colors hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300 sm:text-sm"
+                className="flex items-center gap-1 text-xs font-medium text-indigo-600 transition-colors hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 sm:text-sm"
               >
                 전체보기
                 <svg className="h-3.5 w-3.5 sm:h-4 sm:w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -166,7 +162,7 @@ export default async function Home() {
       <Contact />
 
       {/* Footer */}
-      <footer className="mt-12 border-t border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:mt-16">
+      <footer className="mt-12 border-t border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-900 sm:mt-16">
         <div className="mx-auto max-w-[1000px] px-4 py-6 sm:px-5 sm:py-8">
           <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-between">
             <p className="text-sm font-semibold text-gray-500 dark:text-gray-400">hsm9411</p>

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -117,7 +117,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
   const handleTechClear    = () => updateUrl(1, statusFromUrl, searchFromUrl, sortFromUrl, '')
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
       <div className="mx-auto max-w-[1000px] px-4 py-8 sm:px-5 sm:py-10">
 
         <div className="mb-8 flex items-start justify-between">
@@ -128,7 +128,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
           {isAdmin && (
             <Link
               href="/projects/new"
-              className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
+              className="flex items-center gap-1.5 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-700"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
@@ -144,7 +144,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
             <select
               value={sortFromUrl}
               onChange={(e) => updateUrl(1, statusFromUrl, searchFromUrl, e.target.value, techFromUrl)}
-              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
             >
               {SORT_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
@@ -153,7 +153,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
             <div className="relative flex-1">
               {loading && searchInput ? (
                 <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-teal-500" />
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-indigo-500" />
                 </div>
               ) : (
                 <svg className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -165,14 +165,14 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder="프로젝트 검색..."
-                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-teal-500"
+                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-indigo-500"
               />
             </div>
             {(searchInput || searchFromUrl) && (
               <button
                 type="button"
                 onClick={handleClear}
-                className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
+                className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
               >
                 초기화
               </button>
@@ -194,7 +194,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
               className={`shrink-0 rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors ${
                 statusFromUrl === f.value
                   ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-                  : 'bg-white text-gray-500 ring-1 ring-inset ring-gray-200 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-700 dark:hover:bg-gray-700'
+                  : 'bg-white text-gray-500 ring-1 ring-inset ring-gray-200 hover:bg-zinc-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-700 dark:hover:bg-gray-700'
               }`}
             >
               {f.label}
@@ -206,12 +206,12 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
         {techFromUrl && (
           <div className="mb-4 flex items-center gap-2">
             <span className="text-xs text-gray-400 dark:text-gray-500">기술 스택</span>
-            <span className="flex items-center gap-1.5 rounded-full bg-teal-100 py-1 pl-3 pr-2 text-xs font-semibold text-teal-700 dark:bg-teal-900/40 dark:text-teal-400">
+            <span className="flex items-center gap-1.5 rounded-full bg-indigo-100 py-1 pl-3 pr-2 text-xs font-semibold text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-400">
               {techFromUrl}
               <button
                 type="button"
                 onClick={handleTechClear}
-                className="flex h-4 w-4 items-center justify-center rounded-full hover:bg-teal-200 dark:hover:bg-teal-800"
+                className="flex h-4 w-4 items-center justify-center rounded-full hover:bg-indigo-200 dark:hover:bg-indigo-800"
                 aria-label="기술 스택 필터 해제"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
@@ -240,14 +240,14 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                     : '프로젝트가 없습니다.'}
             </p>
             {isAdmin && !searchFromUrl && statusFromUrl === 'all' && !techFromUrl && (
-              <Link href="/projects/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-700">
+              <Link href="/projects/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700">
                 첫 프로젝트 작성하기
               </Link>
             )}
             {(searchFromUrl || statusFromUrl !== 'all' || techFromUrl) && (
               <button
                 onClick={() => { setSearchInput(''); updateUrl(1, 'all', '', sortFromUrl, '') }}
-                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400"
+                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-400"
               >
                 전체 목록으로
               </button>
@@ -268,7 +268,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                 <button
                   onClick={() => handlePageChange(Math.max(1, pageFromUrl - 1))}
                   disabled={pageFromUrl === 1}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -280,7 +280,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                 <button
                   onClick={() => handlePageChange(Math.min(totalPages, pageFromUrl + 1))}
                   disabled={pageFromUrl === totalPages}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -144,7 +144,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
             <select
               value={sortFromUrl}
               onChange={(e) => updateUrl(1, statusFromUrl, searchFromUrl, e.target.value, techFromUrl)}
-              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300"
             >
               {SORT_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
@@ -165,14 +165,14 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder="프로젝트 검색..."
-                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-indigo-500"
+                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-indigo-500"
               />
             </div>
             {(searchInput || searchFromUrl) && (
               <button
                 type="button"
                 onClick={handleClear}
-                className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
+                className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400 dark:hover:bg-gray-700"
               >
                 초기화
               </button>
@@ -194,7 +194,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
               className={`shrink-0 rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors ${
                 statusFromUrl === f.value
                   ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-                  : 'bg-white text-gray-500 ring-1 ring-inset ring-gray-200 hover:bg-zinc-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-700 dark:hover:bg-gray-700'
+                  : 'bg-white text-gray-500 ring-1 ring-inset ring-gray-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-gray-400 dark:ring-gray-700 dark:hover:bg-gray-700'
               }`}
             >
               {f.label}
@@ -229,7 +229,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
             ))}
           </div>
         ) : projects.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-gray-200 py-24 text-center dark:border-gray-700">
+          <div className="rounded-2xl border border-dashed border-gray-200 py-24 text-center dark:border-zinc-700">
             <p className="text-sm text-gray-400 dark:text-gray-500">
               {techFromUrl
                 ? `"${techFromUrl}" 기술 스택을 사용한 프로젝트가 없습니다.`
@@ -247,7 +247,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
             {(searchFromUrl || statusFromUrl !== 'all' || techFromUrl) && (
               <button
                 onClick={() => { setSearchInput(''); updateUrl(1, 'all', '', sortFromUrl, '') }}
-                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-400"
+                className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-400"
               >
                 전체 목록으로
               </button>
@@ -268,7 +268,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                 <button
                   onClick={() => handlePageChange(Math.max(1, pageFromUrl - 1))}
                   disabled={pageFromUrl === 1}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -280,7 +280,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                 <button
                   onClick={() => handlePageChange(Math.min(totalPages, pageFromUrl + 1))}
                   disabled={pageFromUrl === totalPages}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:bg-zinc-50 disabled:opacity-40 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -128,7 +128,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
           {isAdmin && (
             <Link
               href="/projects/new"
-              className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+              className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
@@ -144,7 +144,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
             <select
               value={sortFromUrl}
               onChange={(e) => updateUrl(1, statusFromUrl, searchFromUrl, e.target.value, techFromUrl)}
-              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              className="shrink-0 rounded-lg border border-gray-200 bg-white py-2.5 pl-3 pr-8 text-sm text-gray-700 transition-colors focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
             >
               {SORT_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
@@ -153,7 +153,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
             <div className="relative flex-1">
               {loading && searchInput ? (
                 <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-blue-500" />
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-teal-500" />
                 </div>
               ) : (
                 <svg className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -165,7 +165,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder="프로젝트 검색..."
-                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-blue-500"
+                className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-10 pr-4 text-sm text-gray-900 transition-colors focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 dark:focus:border-teal-500"
               />
             </div>
             {(searchInput || searchFromUrl) && (
@@ -206,12 +206,12 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
         {techFromUrl && (
           <div className="mb-4 flex items-center gap-2">
             <span className="text-xs text-gray-400 dark:text-gray-500">기술 스택</span>
-            <span className="flex items-center gap-1.5 rounded-full bg-blue-100 py-1 pl-3 pr-2 text-xs font-semibold text-blue-700 dark:bg-blue-900/40 dark:text-blue-400">
+            <span className="flex items-center gap-1.5 rounded-full bg-teal-100 py-1 pl-3 pr-2 text-xs font-semibold text-teal-700 dark:bg-teal-900/40 dark:text-teal-400">
               {techFromUrl}
               <button
                 type="button"
                 onClick={handleTechClear}
-                className="flex h-4 w-4 items-center justify-center rounded-full hover:bg-blue-200 dark:hover:bg-blue-800"
+                className="flex h-4 w-4 items-center justify-center rounded-full hover:bg-teal-200 dark:hover:bg-teal-800"
                 aria-label="기술 스택 필터 해제"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
@@ -240,7 +240,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
                     : '프로젝트가 없습니다.'}
             </p>
             {isAdmin && !searchFromUrl && statusFromUrl === 'all' && !techFromUrl && (
-              <Link href="/projects/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">
+              <Link href="/projects/new" className="mt-4 inline-flex items-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-700">
                 첫 프로젝트 작성하기
               </Link>
             )}

--- a/app/projects/ProjectsClient.tsx
+++ b/app/projects/ProjectsClient.tsx
@@ -172,7 +172,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
               <button
                 type="button"
                 onClick={handleClear}
-                className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400 dark:hover:bg-gray-700"
+                className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-400 dark:hover:bg-zinc-700"
               >
                 초기화
               </button>
@@ -194,7 +194,7 @@ export default function ProjectsClient({ initialData }: { initialData: InitialDa
               className={`shrink-0 rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors ${
                 statusFromUrl === f.value
                   ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-                  : 'bg-white text-gray-500 ring-1 ring-inset ring-gray-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-gray-400 dark:ring-gray-700 dark:hover:bg-gray-700'
+                  : 'bg-white text-gray-500 ring-1 ring-inset ring-gray-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-gray-400 dark:ring-zinc-700 dark:hover:bg-zinc-700'
               }`}
             >
               {f.label}

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -92,7 +92,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
               <span className="font-medium text-gray-900 dark:text-white">{'"'}{project.title}{'"'}</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="flex gap-3">
-              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-gray-700">취소</button>
+              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-zinc-700">취소</button>
               <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60">
                 {deleting ? (
                   <span className="flex items-center justify-center gap-1.5">
@@ -123,7 +123,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
                 className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium shadow-sm transition-colors ${
                   copied
                     ? 'border-green-200 bg-green-50 text-green-600 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400'
-                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700'
                 }`}
               >
                 {copied ? (
@@ -144,7 +144,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
               </button>
               {isAdmin && (
                 <>
-                  <button onClick={() => router.push(`/projects/${project.id}/edit`)} className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700">
+                  <button onClick={() => router.push(`/projects/${project.id}/edit`)} className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700">
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                     </svg>
@@ -201,7 +201,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
           )}
 
           {project.techStack?.length > 0 && (
-            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700">
+            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-zinc-700">
               <h2 className="mb-4 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">🛠 Tech Stack</h2>
               <div className="flex flex-wrap gap-2">
                 {project.techStack.map((tech) => (
@@ -212,7 +212,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
           )}
 
           {project.tags?.length > 0 && (
-            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700">
+            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-zinc-700">
               <h2 className="mb-4 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">🏷 Tags</h2>
               <div className="flex flex-wrap gap-2">
                 {project.tags.map((tag) => (
@@ -222,7 +222,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
             </section>
           )}
 
-          <section className="-mx-5 bg-white px-5 py-6 dark:bg-zinc-800 sm:mx-0 sm:rounded-2xl sm:px-8 sm:py-8 sm:shadow-sm sm:ring-1 sm:ring-gray-200 dark:sm:ring-gray-700">
+          <section className="-mx-5 bg-white px-5 py-6 dark:bg-zinc-800 sm:mx-0 sm:rounded-2xl sm:px-8 sm:py-8 sm:shadow-sm sm:ring-1 sm:ring-gray-200 dark:sm:ring-zinc-700">
             <h2 className="mb-5 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">📋 Description</h2>
             <div className="markdown-body">
               <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>{project.description}</ReactMarkdown>
@@ -238,7 +238,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
                 </a>
               )}
               {project.githubUrl && (
-                <a href={project.githubUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-700 dark:bg-zinc-700 dark:hover:bg-gray-600">
+                <a href={project.githubUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-700 dark:bg-zinc-700 dark:hover:bg-zinc-600">
                   <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" /></svg>
                   GitHub
                 </a>
@@ -249,10 +249,10 @@ export default function ProjectDetailClient({ project, from }: Props) {
           <UpdateTimeline projectId={project.id} />
 
           {/* 실시간 영역 — 클라이언트에서 별도 fetch */}
-          <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700">
+          <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-zinc-700">
             <LikeButton targetType="project" targetId={project.id} initialLikeCount={project.likeCount} />
           </div>
-          <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700 sm:p-8">
+          <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-zinc-700 sm:p-8">
             <CommentSection targetType="project" targetId={project.id} />
           </div>
         </div>

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 const statusConfig = {
   completed:   { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
-  'in-progress': { label: '진행중', className: 'bg-teal-50 text-teal-700 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-400 dark:ring-teal-500/30' },
+  'in-progress': { label: '진행중', className: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-400 dark:ring-indigo-500/30' },
   archived:    { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
@@ -76,7 +76,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
   }), [])
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
 
       {/* 삭제 확인 모달 */}
       {showDeleteConfirm && (
@@ -92,7 +92,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
               <span className="font-medium text-gray-900 dark:text-white">{'"'}{project.title}{'"'}</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="flex gap-3">
-              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700">취소</button>
+              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700">취소</button>
               <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60">
                 {deleting ? (
                   <span className="flex items-center justify-center gap-1.5">
@@ -123,7 +123,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
                 className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium shadow-sm transition-colors ${
                   copied
                     ? 'border-green-200 bg-green-50 text-green-600 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400'
-                    : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
                 }`}
               >
                 {copied ? (
@@ -144,7 +144,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
               </button>
               {isAdmin && (
                 <>
-                  <button onClick={() => router.push(`/projects/${project.id}/edit`)} className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700">
+                  <button onClick={() => router.push(`/projects/${project.id}/edit`)} className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700">
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                     </svg>
@@ -205,7 +205,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
               <h2 className="mb-4 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">🛠 Tech Stack</h2>
               <div className="flex flex-wrap gap-2">
                 {project.techStack.map((tech) => (
-                  <span key={tech} className="rounded-lg bg-teal-50 px-3 py-1.5 text-sm font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300 dark:ring-teal-500/30">{tech}</span>
+                  <span key={tech} className="rounded-lg bg-indigo-50 px-3 py-1.5 text-sm font-semibold text-indigo-700 ring-1 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-300 dark:ring-indigo-500/30">{tech}</span>
                 ))}
               </div>
             </section>
@@ -232,7 +232,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
           {(project.demoUrl || project.githubUrl) && (
             <div className="flex flex-wrap gap-3">
               {project.demoUrl && (
-                <a href={project.demoUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-xl bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-teal-700">
+                <a href={project.demoUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-700">
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" /></svg>
                   데모 보기
                 </a>

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -25,7 +25,7 @@ interface Props {
 const statusConfig = {
   completed:   { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
   'in-progress': { label: '진행중', className: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-400 dark:ring-indigo-500/30' },
-  archived:    { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
+  archived:    { label: '보관',   className: 'bg-zinc-100 text-gray-600 ring-gray-500/20 dark:bg-zinc-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
 export default function ProjectDetailClient({ project, from }: Props) {
@@ -81,7 +81,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
       {/* 삭제 확인 모달 */}
       {showDeleteConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 backdrop-blur-sm">
-          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-2xl dark:bg-gray-800">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-2xl dark:bg-zinc-800">
             <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
               <svg className="h-6 w-6 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -92,7 +92,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
               <span className="font-medium text-gray-900 dark:text-white">{'"'}{project.title}{'"'}</span>을(를) 삭제합니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="flex gap-3">
-              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700">취소</button>
+              <button onClick={() => setShowDeleteConfirm(false)} className="flex-1 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-gray-700">취소</button>
               <button onClick={handleDelete} disabled={deleting} className="flex-1 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60">
                 {deleting ? (
                   <span className="flex items-center justify-center gap-1.5">
@@ -107,7 +107,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
       )}
 
       {/* 헤더 */}
-      <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-800/50">
+      <header className="border-b border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-800/50">
         <div className="mx-auto max-w-[1000px] px-5 pt-5 pb-10 sm:pt-7">
           {/* 뒤로가기 + 공유 + 관리자 액션 */}
           <div className="mb-5 flex items-center justify-between sm:mb-6">
@@ -123,7 +123,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
                 className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium shadow-sm transition-colors ${
                   copied
                     ? 'border-green-200 bg-green-50 text-green-600 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400'
-                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                    : 'border-gray-200 bg-white text-gray-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700'
                 }`}
               >
                 {copied ? (
@@ -144,13 +144,13 @@ export default function ProjectDetailClient({ project, from }: Props) {
               </button>
               {isAdmin && (
                 <>
-                  <button onClick={() => router.push(`/projects/${project.id}/edit`)} className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700">
+                  <button onClick={() => router.push(`/projects/${project.id}/edit`)} className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700">
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                     </svg>
                     수정
                   </button>
-                  <button onClick={() => setShowDeleteConfirm(true)} className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-gray-800 dark:text-red-400 dark:hover:bg-red-900/20">
+                  <button onClick={() => setShowDeleteConfirm(true)} className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 shadow-sm transition-colors hover:bg-red-50 dark:border-red-900/50 dark:bg-zinc-800 dark:text-red-400 dark:hover:bg-red-900/20">
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                     </svg>
@@ -201,7 +201,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
           )}
 
           {project.techStack?.length > 0 && (
-            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700">
+            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700">
               <h2 className="mb-4 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">🛠 Tech Stack</h2>
               <div className="flex flex-wrap gap-2">
                 {project.techStack.map((tech) => (
@@ -212,17 +212,17 @@ export default function ProjectDetailClient({ project, from }: Props) {
           )}
 
           {project.tags?.length > 0 && (
-            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700">
+            <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700">
               <h2 className="mb-4 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">🏷 Tags</h2>
               <div className="flex flex-wrap gap-2">
                 {project.tags.map((tag) => (
-                  <span key={tag} className="rounded-lg bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">#{tag}</span>
+                  <span key={tag} className="rounded-lg bg-zinc-100 px-3 py-1.5 text-sm font-medium text-gray-700 dark:bg-zinc-700 dark:text-gray-300">#{tag}</span>
                 ))}
               </div>
             </section>
           )}
 
-          <section className="-mx-5 bg-white px-5 py-6 dark:bg-gray-800 sm:mx-0 sm:rounded-2xl sm:px-8 sm:py-8 sm:shadow-sm sm:ring-1 sm:ring-gray-200 dark:sm:ring-gray-700">
+          <section className="-mx-5 bg-white px-5 py-6 dark:bg-zinc-800 sm:mx-0 sm:rounded-2xl sm:px-8 sm:py-8 sm:shadow-sm sm:ring-1 sm:ring-gray-200 dark:sm:ring-gray-700">
             <h2 className="mb-5 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">📋 Description</h2>
             <div className="markdown-body">
               <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={markdownComponents}>{project.description}</ReactMarkdown>
@@ -238,7 +238,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
                 </a>
               )}
               {project.githubUrl && (
-                <a href={project.githubUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600">
+                <a href={project.githubUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-700 dark:bg-zinc-700 dark:hover:bg-gray-600">
                   <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" /></svg>
                   GitHub
                 </a>
@@ -249,10 +249,10 @@ export default function ProjectDetailClient({ project, from }: Props) {
           <UpdateTimeline projectId={project.id} />
 
           {/* 실시간 영역 — 클라이언트에서 별도 fetch */}
-          <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700">
+          <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700">
             <LikeButton targetType="project" targetId={project.id} initialLikeCount={project.likeCount} />
           </div>
-          <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:p-8">
+          <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700 sm:p-8">
             <CommentSection targetType="project" targetId={project.id} />
           </div>
         </div>

--- a/app/projects/[id]/ProjectDetailClient.tsx
+++ b/app/projects/[id]/ProjectDetailClient.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
@@ -24,7 +24,7 @@ interface Props {
 
 const statusConfig = {
   completed:   { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
-  'in-progress': { label: '진행중', className: 'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-400 dark:ring-blue-500/30' },
+  'in-progress': { label: '진행중', className: 'bg-teal-50 text-teal-700 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-400 dark:ring-teal-500/30' },
   archived:    { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
@@ -205,7 +205,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
               <h2 className="mb-4 text-base font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">🛠 Tech Stack</h2>
               <div className="flex flex-wrap gap-2">
                 {project.techStack.map((tech) => (
-                  <span key={tech} className="rounded-lg bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30">{tech}</span>
+                  <span key={tech} className="rounded-lg bg-teal-50 px-3 py-1.5 text-sm font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300 dark:ring-teal-500/30">{tech}</span>
                 ))}
               </div>
             </section>
@@ -232,7 +232,7 @@ export default function ProjectDetailClient({ project, from }: Props) {
           {(project.demoUrl || project.githubUrl) && (
             <div className="flex flex-wrap gap-3">
               {project.demoUrl && (
-                <a href={project.demoUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700">
+                <a href={project.demoUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-xl bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-teal-700">
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" /></svg>
                   데모 보기
                 </a>

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -23,7 +23,7 @@ import rehypeHighlight from 'rehype-highlight'
 const STATUS_CONFIG = {
   'in-progress': { label: '진행중', className: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-400 dark:ring-indigo-500/30' },
   completed:     { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
-  archived:      { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
+  archived:      { label: '보관',   className: 'bg-zinc-100 text-gray-600 ring-gray-500/20 dark:bg-zinc-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
 export default function EditProjectPage() {
@@ -158,7 +158,7 @@ export default function EditProjectPage() {
 
         {!preview ? (
           <form id="edit-project-form" onSubmit={handleSubmit}>
-            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-800 sm:p-8">
 
               {/* 기본 정보 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기본 정보</p>
@@ -200,7 +200,7 @@ export default function EditProjectPage() {
                 </FormField>
               </div>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 이미지 갤러리 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">이미지 갤러리</p>
@@ -211,7 +211,7 @@ export default function EditProjectPage() {
                 />
               </FormField>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 상세 설명 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">상세 설명 (Markdown)</p>
@@ -228,7 +228,7 @@ export default function EditProjectPage() {
                 </p>
               </FormField>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 기술 & 태그 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기술 & 태그</p>
@@ -245,7 +245,7 @@ export default function EditProjectPage() {
                 />
               </FormField>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 링크 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">링크</p>
@@ -273,7 +273,7 @@ export default function EditProjectPage() {
             </div>
           </form>
         ) : (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800 sm:p-12">
+          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-zinc-700 dark:bg-zinc-800 sm:p-12">
             <div className="mb-4">
               <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ${STATUS_CONFIG[formData.status].className}`}>
                 {STATUS_CONFIG[formData.status].label}

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
@@ -21,7 +21,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 
 const STATUS_CONFIG = {
-  'in-progress': { label: '진행중', className: 'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-400 dark:ring-blue-500/30' },
+  'in-progress': { label: '진행중', className: 'bg-teal-50 text-teal-700 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-400 dark:ring-teal-500/30' },
   completed:     { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
   archived:      { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
@@ -288,7 +288,7 @@ export default function EditProjectPage() {
             {formData.techStack.length > 0 && (
               <div className="mb-6 flex flex-wrap gap-2">
                 {formData.techStack.map((tech) => (
-                  <span key={tech} className="rounded-lg bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30">
+                  <span key={tech} className="rounded-lg bg-teal-50 px-3 py-1.5 text-sm font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300 dark:ring-teal-500/30">
                     {tech}
                   </span>
                 ))}

--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -21,7 +21,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 
 const STATUS_CONFIG = {
-  'in-progress': { label: '진행중', className: 'bg-teal-50 text-teal-700 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-400 dark:ring-teal-500/30' },
+  'in-progress': { label: '진행중', className: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-400 dark:ring-indigo-500/30' },
   completed:     { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
   archived:      { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
@@ -131,7 +131,7 @@ export default function EditProjectPage() {
   if (!isAdmin) return null
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
       <ConfirmDialog
         open={showCancelConfirm}
         title="수정 취소"
@@ -288,7 +288,7 @@ export default function EditProjectPage() {
             {formData.techStack.length > 0 && (
               <div className="mb-6 flex flex-wrap gap-2">
                 {formData.techStack.map((tech) => (
-                  <span key={tech} className="rounded-lg bg-teal-50 px-3 py-1.5 text-sm font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300 dark:ring-teal-500/30">
+                  <span key={tech} className="rounded-lg bg-indigo-50 px-3 py-1.5 text-sm font-semibold text-indigo-700 ring-1 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-300 dark:ring-indigo-500/30">
                     {tech}
                   </span>
                 ))}

--- a/app/projects/error.tsx
+++ b/app/projects/error.tsx
@@ -38,7 +38,7 @@ export default function ProjectsError({ error, reset }: Props) {
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-zinc-700"
           >
             홈으로
           </Link>

--- a/app/projects/error.tsx
+++ b/app/projects/error.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useEffect } from 'react'
 import Link from 'next/link'
@@ -32,7 +32,7 @@ export default function ProjectsError({ error, reset }: Props) {
         <div className="flex justify-center gap-3">
           <button
             onClick={reset}
-            className="rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+            className="rounded-xl bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
           >
             다시 시도
           </button>

--- a/app/projects/error.tsx
+++ b/app/projects/error.tsx
@@ -14,7 +14,7 @@ export default function ProjectsError({ error, reset }: Props) {
   }, [error])
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 dark:bg-zinc-900">
       <div className="w-full max-w-md text-center">
         <div className="mb-6 flex justify-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
@@ -32,13 +32,13 @@ export default function ProjectsError({ error, reset }: Props) {
         <div className="flex justify-center gap-3">
           <button
             onClick={reset}
-            className="rounded-xl bg-teal-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-teal-700"
+            className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-700"
           >
             다시 시도
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             홈으로
           </Link>

--- a/app/projects/error.tsx
+++ b/app/projects/error.tsx
@@ -38,7 +38,7 @@ export default function ProjectsError({ error, reset }: Props) {
           </button>
           <Link
             href="/"
-            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             홈으로
           </Link>

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -22,7 +22,7 @@ import rehypeHighlight from 'rehype-highlight'
 const STATUS_CONFIG = {
   'in-progress': { label: '진행중', className: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-400 dark:ring-indigo-500/30' },
   completed:     { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
-  archived:      { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
+  archived:      { label: '보관',   className: 'bg-zinc-100 text-gray-600 ring-gray-500/20 dark:bg-zinc-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
 const EMPTY_FORM = {
@@ -127,7 +127,7 @@ export default function NewProjectPage() {
 
         {!preview ? (
           <form id="project-form" onSubmit={handleSubmit}>
-            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 sm:p-8">
+            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-800 sm:p-8">
 
               {/* 기본 정보 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기본 정보</p>
@@ -169,7 +169,7 @@ export default function NewProjectPage() {
                 </FormField>
               </div>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 이미지 갤러리 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">이미지 갤러리</p>
@@ -180,7 +180,7 @@ export default function NewProjectPage() {
                 />
               </FormField>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 상세 설명 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">상세 설명 (Markdown)</p>
@@ -197,7 +197,7 @@ export default function NewProjectPage() {
                 </p>
               </FormField>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 기술 & 태그 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">기술 & 태그</p>
@@ -214,7 +214,7 @@ export default function NewProjectPage() {
                 />
               </FormField>
 
-              <div className="my-6 border-t border-gray-100 dark:border-gray-700" />
+              <div className="my-6 border-t border-gray-100 dark:border-zinc-700" />
 
               {/* 링크 */}
               <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">링크</p>
@@ -242,7 +242,7 @@ export default function NewProjectPage() {
             </div>
           </form>
         ) : (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800 sm:p-12">
+          <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-zinc-700 dark:bg-zinc-800 sm:p-12">
             <div className="mb-4">
               <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ${STATUS_CONFIG[formData.status].className}`}>
                 {STATUS_CONFIG[formData.status].label}

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
@@ -20,7 +20,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 
 const STATUS_CONFIG = {
-  'in-progress': { label: '진행중', className: 'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-400 dark:ring-blue-500/30' },
+  'in-progress': { label: '진행중', className: 'bg-teal-50 text-teal-700 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-400 dark:ring-teal-500/30' },
   completed:     { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
   archived:      { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
@@ -257,7 +257,7 @@ export default function NewProjectPage() {
             {formData.techStack.length > 0 && (
               <div className="mb-6 flex flex-wrap gap-2">
                 {formData.techStack.map((tech) => (
-                  <span key={tech} className="rounded-lg bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-700 ring-1 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30">
+                  <span key={tech} className="rounded-lg bg-teal-50 px-3 py-1.5 text-sm font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300 dark:ring-teal-500/30">
                     {tech}
                   </span>
                 ))}

--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -20,7 +20,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 
 const STATUS_CONFIG = {
-  'in-progress': { label: '진행중', className: 'bg-teal-50 text-teal-700 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-400 dark:ring-teal-500/30' },
+  'in-progress': { label: '진행중', className: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-400 dark:ring-indigo-500/30' },
   completed:     { label: '완료',   className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
   archived:      { label: '보관',   className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
@@ -99,7 +99,7 @@ export default function NewProjectPage() {
   if (!authReady || !isAdmin) return <Spinner />
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
       <ConfirmDialog
         open={showCancelConfirm}
         title="작성 취소"
@@ -257,7 +257,7 @@ export default function NewProjectPage() {
             {formData.techStack.length > 0 && (
               <div className="mb-6 flex flex-wrap gap-2">
                 {formData.techStack.map((tech) => (
-                  <span key={tech} className="rounded-lg bg-teal-50 px-3 py-1.5 text-sm font-semibold text-teal-700 ring-1 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-300 dark:ring-teal-500/30">
+                  <span key={tech} className="rounded-lg bg-indigo-50 px-3 py-1.5 text-sm font-semibold text-indigo-700 ring-1 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-300 dark:ring-indigo-500/30">
                     {tech}
                   </span>
                 ))}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -24,8 +24,8 @@ export default async function ProjectsPage() {
 
   return (
     <Suspense fallback={
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-teal-600" />
+      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
+        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-indigo-600" />
       </div>
     }>
       <ProjectsClient initialData={initialData} />

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+﻿import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import { fetchProjects } from '@/lib/api/server'
 import ProjectsClient from './ProjectsClient'
@@ -25,7 +25,7 @@ export default async function ProjectsPage() {
   return (
     <Suspense fallback={
       <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-blue-600" />
+        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-gray-200 border-t-teal-600" />
       </div>
     }>
       <ProjectsClient initialData={initialData} />

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { createClient } from '@/lib/supabase/client'
 import { useEffect, useState, useRef } from 'react'
@@ -75,7 +75,7 @@ export default function AuthButton() {
               className="h-7 w-7 rounded-full object-cover ring-1 ring-gray-200 dark:ring-white/10"
             />
           ) : (
-            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-blue-600 text-[11px] font-bold text-white">
+            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-teal-600 text-[11px] font-bold text-white">
               {displayName.charAt(0).toUpperCase()}
             </div>
           )}

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -75,14 +75,14 @@ export default function AuthButton() {
               className="h-7 w-7 rounded-full object-cover ring-1 ring-gray-200 dark:ring-white/10"
             />
           ) : (
-            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-teal-600 text-[11px] font-bold text-white">
+            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-indigo-600 text-[11px] font-bold text-white">
               {displayName.charAt(0).toUpperCase()}
             </div>
           )}
         </button>
 
         {open && (
-          <div className="absolute right-0 mt-2.5 w-52 overflow-hidden rounded-xl border border-gray-100 bg-white shadow-lg dark:border-white/[0.08] dark:bg-gray-900">
+          <div className="absolute right-0 mt-2.5 w-52 overflow-hidden rounded-xl border border-gray-100 bg-white shadow-lg dark:border-white/[0.08] dark:bg-zinc-900">
             <div className="border-b border-gray-100 px-4 py-3 dark:border-white/[0.06]">
               <p className="text-xs font-semibold text-gray-900 dark:text-white">{displayName}</p>
               <p className="mt-0.5 truncate text-[11px] text-gray-400 dark:text-gray-500">{user.email}</p>

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -47,7 +47,7 @@ export default function AuthButton() {
 
   // 로딩 중: 자리 유지용 스켈레톤
   if (loading) {
-    return <div className="h-7 w-7 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+    return <div className="h-7 w-7 animate-pulse rounded-full bg-gray-200 dark:bg-zinc-700" />
   }
 
   // 로그인 상태: 아바타만

--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -262,7 +262,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                       <button
                         type="button"
                         onClick={handleEditCancel}
-                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-gray-700"
+                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-zinc-700"
                       >
                         취소
                       </button>

--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
@@ -142,7 +142,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       <form onSubmit={handleSubmit} className="mb-8">
         <div className={`rounded-xl border transition-colors ${
           isAuthenticated
-            ? 'border-gray-200 focus-within:border-blue-400 dark:border-gray-700 dark:focus-within:border-blue-500'
+            ? 'border-gray-200 focus-within:border-teal-400 dark:border-gray-700 dark:focus-within:border-teal-500'
             : 'border-gray-200 dark:border-gray-700'
         } bg-gray-50 dark:bg-gray-900`}>
           <textarea
@@ -158,7 +158,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
               <button
                 type="button"
                 onClick={() => router.push('/login')}
-                className="text-xs text-blue-500 underline-offset-2 hover:underline dark:text-blue-400"
+                className="text-xs text-teal-500 underline-offset-2 hover:underline dark:text-teal-400"
               >
                 로그인하러 가기
               </button>
@@ -170,7 +170,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
             <button
               type="submit"
               disabled={!isAuthenticated || submitting || !newComment.trim()}
-              className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {submitting ? (
                 <>
@@ -186,7 +186,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       {/* 댓글 목록 */}
       {loading ? (
         <div className="flex justify-center py-8">
-          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600" />
+          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-teal-600" />
         </div>
       ) : comments.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700">
@@ -206,7 +206,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                 <div className="mb-2 flex items-start justify-between gap-3">
                   <div className="flex min-w-0 items-center gap-2">
                     {/* 아바타 이니셜 */}
-                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-violet-500 text-xs font-bold text-white">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-teal-500 to-violet-500 text-xs font-bold text-white">
                       {comment.user.nickname.charAt(0).toUpperCase()}
                     </div>
                     <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
@@ -228,7 +228,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                       <button
                         type="button"
                         onClick={() => handleEditStart(comment)}
-                        className="rounded p-1 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
+                        className="rounded p-1 text-gray-300 transition-colors hover:text-teal-500 dark:text-gray-600 dark:hover:text-teal-400"
                         aria-label="댓글 수정"
                       >
                         <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -256,7 +256,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
                       rows={3}
-                      className="w-full resize-none rounded-lg border border-blue-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-blue-500 dark:bg-gray-800 dark:text-gray-200"
+                      className="w-full resize-none rounded-lg border border-teal-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-teal-500 dark:bg-gray-800 dark:text-gray-200"
                     />
                     <div className="mt-2 flex items-center justify-end gap-2">
                       <button
@@ -270,7 +270,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                         type="button"
                         onClick={() => handleEditSave(comment.id)}
                         disabled={editSubmitting || !editContent.trim() || editContent.trim() === comment.content}
-                        className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                        className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         {editSubmitting ? (
                           <>
@@ -301,7 +301,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
               >
                 {loadingMore ? (
                   <>
-                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-teal-600" />
                     불러오는 중
                   </>
                 ) : (

--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -142,9 +142,9 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       <form onSubmit={handleSubmit} className="mb-8">
         <div className={`rounded-xl border transition-colors ${
           isAuthenticated
-            ? 'border-gray-200 focus-within:border-teal-400 dark:border-gray-700 dark:focus-within:border-teal-500'
+            ? 'border-gray-200 focus-within:border-indigo-400 dark:border-gray-700 dark:focus-within:border-indigo-500'
             : 'border-gray-200 dark:border-gray-700'
-        } bg-gray-50 dark:bg-gray-900`}>
+        } bg-zinc-50 dark:bg-zinc-900`}>
           <textarea
             value={newComment}
             onChange={(e) => setNewComment(e.target.value)}
@@ -158,7 +158,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
               <button
                 type="button"
                 onClick={() => router.push('/login')}
-                className="text-xs text-teal-500 underline-offset-2 hover:underline dark:text-teal-400"
+                className="text-xs text-indigo-500 underline-offset-2 hover:underline dark:text-indigo-400"
               >
                 로그인하러 가기
               </button>
@@ -170,7 +170,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
             <button
               type="submit"
               disabled={!isAuthenticated || submitting || !newComment.trim()}
-              className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-lg bg-indigo-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {submitting ? (
                 <>
@@ -186,7 +186,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       {/* 댓글 목록 */}
       {loading ? (
         <div className="flex justify-center py-8">
-          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-teal-600" />
+          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-indigo-600" />
         </div>
       ) : comments.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700">
@@ -206,7 +206,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                 <div className="mb-2 flex items-start justify-between gap-3">
                   <div className="flex min-w-0 items-center gap-2">
                     {/* 아바타 이니셜 */}
-                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-teal-500 to-violet-500 text-xs font-bold text-white">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 text-xs font-bold text-white">
                       {comment.user.nickname.charAt(0).toUpperCase()}
                     </div>
                     <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
@@ -228,7 +228,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                       <button
                         type="button"
                         onClick={() => handleEditStart(comment)}
-                        className="rounded p-1 text-gray-300 transition-colors hover:text-teal-500 dark:text-gray-600 dark:hover:text-teal-400"
+                        className="rounded p-1 text-gray-300 transition-colors hover:text-indigo-500 dark:text-gray-600 dark:hover:text-indigo-400"
                         aria-label="댓글 수정"
                       >
                         <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -256,7 +256,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
                       rows={3}
-                      className="w-full resize-none rounded-lg border border-teal-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-teal-500 dark:bg-gray-800 dark:text-gray-200"
+                      className="w-full resize-none rounded-lg border border-indigo-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-indigo-500 dark:bg-gray-800 dark:text-gray-200"
                     />
                     <div className="mt-2 flex items-center justify-end gap-2">
                       <button
@@ -270,7 +270,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                         type="button"
                         onClick={() => handleEditSave(comment.id)}
                         disabled={editSubmitting || !editContent.trim() || editContent.trim() === comment.content}
-                        className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
+                        className="flex items-center gap-1.5 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         {editSubmitting ? (
                           <>
@@ -297,11 +297,11 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                 type="button"
                 onClick={loadMore}
                 disabled={loadingMore}
-                className="flex items-center gap-2 rounded-lg border border-gray-200 px-5 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                className="flex items-center gap-2 rounded-lg border border-gray-200 px-5 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
               >
                 {loadingMore ? (
                   <>
-                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-teal-600" />
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-indigo-600" />
                     불러오는 중
                   </>
                 ) : (

--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -142,8 +142,8 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
       <form onSubmit={handleSubmit} className="mb-8">
         <div className={`rounded-xl border transition-colors ${
           isAuthenticated
-            ? 'border-gray-200 focus-within:border-indigo-400 dark:border-gray-700 dark:focus-within:border-indigo-500'
-            : 'border-gray-200 dark:border-gray-700'
+            ? 'border-gray-200 focus-within:border-indigo-400 dark:border-zinc-700 dark:focus-within:border-indigo-500'
+            : 'border-gray-200 dark:border-zinc-700'
         } bg-zinc-50 dark:bg-zinc-900`}>
           <textarea
             value={newComment}
@@ -153,7 +153,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
             rows={3}
             className="w-full resize-none rounded-xl bg-transparent px-4 py-3 text-sm text-gray-800 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:placeholder-gray-500"
           />
-          <div className="flex items-center justify-between border-t border-gray-200 px-4 py-2.5 dark:border-gray-700">
+          <div className="flex items-center justify-between border-t border-gray-200 px-4 py-2.5 dark:border-zinc-700">
             {!isAuthenticated ? (
               <button
                 type="button"
@@ -189,7 +189,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
           <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-indigo-600" />
         </div>
       ) : comments.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700">
+        <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-zinc-700">
           <svg className="mx-auto mb-3 h-10 w-10 text-gray-300 dark:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
           </svg>
@@ -201,7 +201,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
             {comments.map((comment) => (
               <div
                 key={comment.id}
-                className="border-b border-gray-100 py-4 last:border-b-0 dark:border-gray-800"
+                className="border-b border-gray-100 py-4 last:border-b-0 dark:border-zinc-800"
               >
                 <div className="mb-2 flex items-start justify-between gap-3">
                   <div className="flex min-w-0 items-center gap-2">
@@ -214,7 +214,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                         {comment.user.nickname}
                       </span>
                       {comment.isAnonymous && (
-                        <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                        <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-gray-500 dark:bg-zinc-700 dark:text-gray-400">
                           익명
                         </span>
                       )}
@@ -256,13 +256,13 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
                       rows={3}
-                      className="w-full resize-none rounded-lg border border-indigo-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-indigo-500 dark:bg-gray-800 dark:text-gray-200"
+                      className="w-full resize-none rounded-lg border border-indigo-400 bg-white px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-indigo-500 dark:bg-zinc-800 dark:text-gray-200"
                     />
                     <div className="mt-2 flex items-center justify-end gap-2">
                       <button
                         type="button"
                         onClick={handleEditCancel}
-                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-gray-700"
                       >
                         취소
                       </button>
@@ -297,7 +297,7 @@ export default function CommentSection({ targetType, targetId }: CommentSectionP
                 type="button"
                 onClick={loadMore}
                 disabled={loadingMore}
-                className="flex items-center gap-2 rounded-lg border border-gray-200 px-5 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                className="flex items-center gap-2 rounded-lg border border-gray-200 px-5 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-gray-400 dark:hover:bg-zinc-800"
               >
                 {loadingMore ? (
                   <>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -32,7 +32,7 @@ export default function Contact() {
   }
 
   return (
-    <section className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-zinc-900">
+    <section className="border-b border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
       <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
         <h2 className="mb-3 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-4 md:text-3xl">
           Contact
@@ -47,26 +47,26 @@ export default function Contact() {
             name="user_name"
             placeholder="이름 (Name)"
             required
-            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
           />
           <input
             type="email"
             name="user_email"
             placeholder="이메일 (Email)"
             required
-            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
           />
           <textarea
             name="message"
             placeholder="내용을 입력해주세요 (Message)"
             required
             rows={6}
-            className="w-full resize-y rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
+            className="w-full resize-y rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
           />
           <button
             type="submit"
             disabled={status === 'sending'}
-            className="w-full rounded-lg bg-gray-900 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-50 dark:bg-gray-100 dark:text-gray-900 sm:py-[15px] sm:text-[1.05rem]"
+            className="w-full rounded-lg bg-gray-900 py-3 text-sm font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-50 dark:bg-zinc-100 dark:text-gray-900 sm:py-[15px] sm:text-[1.05rem]"
           >
             {status === 'sending' ? '전송 중...' : '메일 보내기'}
           </button>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -32,7 +32,7 @@ export default function Contact() {
   }
 
   return (
-    <section className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+    <section className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-zinc-900">
       <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
         <h2 className="mb-3 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-4 md:text-3xl">
           Contact
@@ -47,21 +47,21 @@ export default function Contact() {
             name="user_name"
             placeholder="이름 (Name)"
             required
-            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-teal-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-teal-400 sm:py-[15px] sm:text-base"
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
           />
           <input
             type="email"
             name="user_email"
             placeholder="이메일 (Email)"
             required
-            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-teal-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-teal-400 sm:py-[15px] sm:text-base"
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
           />
           <textarea
             name="message"
             placeholder="내용을 입력해주세요 (Message)"
             required
             rows={6}
-            className="w-full resize-y rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-teal-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-teal-400 sm:py-[15px] sm:text-base"
+            className="w-full resize-y rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-indigo-400 sm:py-[15px] sm:text-base"
           />
           <button
             type="submit"

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useRef, useState } from 'react'
 import emailjs from '@emailjs/browser'
@@ -47,21 +47,21 @@ export default function Contact() {
             name="user_name"
             placeholder="이름 (Name)"
             required
-            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400 sm:py-[15px] sm:text-base"
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-teal-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-teal-400 sm:py-[15px] sm:text-base"
           />
           <input
             type="email"
             name="user_email"
             placeholder="이메일 (Email)"
             required
-            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400 sm:py-[15px] sm:text-base"
+            className="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-teal-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-teal-400 sm:py-[15px] sm:text-base"
           />
           <textarea
             name="message"
             placeholder="내용을 입력해주세요 (Message)"
             required
             rows={6}
-            className="w-full resize-y rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-blue-400 sm:py-[15px] sm:text-base"
+            className="w-full resize-y rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition-colors focus:border-teal-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:focus:border-teal-400 sm:py-[15px] sm:text-base"
           />
           <button
             type="submit"

--- a/components/EditorBar.tsx
+++ b/components/EditorBar.tsx
@@ -23,7 +23,7 @@ export default function EditorBar({
   const hasPreviewToggle = preview !== undefined && onPreviewChange !== undefined
 
   return (
-    <div className="sticky z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-gray-900/90" style={{ top: 'var(--navbar-h, 72px)' }}>
+    <div className="sticky z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-zinc-900/90" style={{ top: 'var(--navbar-h, 72px)' }}>
       <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
 
         {/* 왼쪽: 취소 + 구분선 + 제목 + 미저장 표시 */}
@@ -77,7 +77,7 @@ export default function EditorBar({
             form={formId}
             type="submit"
             disabled={submitting || !hasChanges}
-            className="flex shrink-0 items-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex shrink-0 items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {submitting ? (
               <>

--- a/components/EditorBar.tsx
+++ b/components/EditorBar.tsx
@@ -23,7 +23,7 @@ export default function EditorBar({
   const hasPreviewToggle = preview !== undefined && onPreviewChange !== undefined
 
   return (
-    <div className="sticky z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-gray-800 dark:bg-zinc-900/90" style={{ top: 'var(--navbar-h, 72px)' }}>
+    <div className="sticky z-40 border-b border-gray-200 bg-white/90 backdrop-blur-md dark:border-zinc-800 dark:bg-zinc-900/90" style={{ top: 'var(--navbar-h, 72px)' }}>
       <div className="mx-auto flex max-w-[1000px] items-center justify-between px-5 py-3">
 
         {/* 왼쪽: 취소 + 구분선 + 제목 + 미저장 표시 */}
@@ -38,7 +38,7 @@ export default function EditorBar({
             </svg>
             취소
           </button>
-          <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-700" />
+          <span className="h-4 w-px shrink-0 bg-gray-200 dark:bg-zinc-700" />
           <span className="truncate text-sm font-semibold text-gray-700 dark:text-gray-300">{title}</span>
           {hasChanges && (
             <span className="shrink-0 text-xs text-amber-600 dark:text-amber-400">● 미저장</span>
@@ -48,13 +48,13 @@ export default function EditorBar({
         {/* 오른쪽: 편집/미리보기 토글(선택) + 저장 버튼 */}
         <div className="flex shrink-0 items-center gap-2">
           {hasPreviewToggle && (
-            <div className="flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex rounded-lg border border-gray-200 bg-zinc-100 p-0.5 dark:border-zinc-700 dark:bg-zinc-800">
               <button
                 type="button"
                 onClick={() => onPreviewChange(false)}
                 className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
                   !preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-zinc-700 dark:text-white'
                     : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
                 }`}
               >
@@ -65,7 +65,7 @@ export default function EditorBar({
                 onClick={() => onPreviewChange(true)}
                 className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
                   preview
-                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-zinc-700 dark:text-white'
                     : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
                 }`}
               >

--- a/components/EditorBar.tsx
+++ b/components/EditorBar.tsx
@@ -1,4 +1,4 @@
-interface EditorBarProps {
+﻿interface EditorBarProps {
   title: string
   hasChanges: boolean
   submitting: boolean
@@ -77,7 +77,7 @@ export default function EditorBar({
             form={formId}
             type="submit"
             disabled={submitting || !hasChanges}
-            className="flex shrink-0 items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex shrink-0 items-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {submitting ? (
               <>

--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -2,7 +2,7 @@
 
 export default function Education() {
   return (
-    <section className="border-b border-gray-200 bg-zinc-50 dark:border-gray-800 dark:bg-zinc-900/50">
+    <section className="border-b border-gray-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900/50">
       <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
         <h2 className="mb-8 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-12 md:text-3xl">
           Education
@@ -11,7 +11,7 @@ export default function Education() {
           {educations.map((edu) => (
             <div
               key={edu.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-indigo-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-indigo-400 sm:p-6 md:p-8"
+              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-indigo-500 dark:border-zinc-700 dark:border-l-gray-200 dark:hover:border-zinc-500 dark:hover:border-l-indigo-400 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{edu.course}</span>

--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -2,7 +2,7 @@
 
 export default function Education() {
   return (
-    <section className="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50">
+    <section className="border-b border-gray-200 bg-zinc-50 dark:border-gray-800 dark:bg-zinc-900/50">
       <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
         <h2 className="mb-8 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-12 md:text-3xl">
           Education
@@ -11,7 +11,7 @@ export default function Education() {
           {educations.map((edu) => (
             <div
               key={edu.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-teal-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-teal-400 sm:p-6 md:p-8"
+              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-indigo-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-indigo-400 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{edu.course}</span>
@@ -22,12 +22,12 @@ export default function Education() {
                   href={edu.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mb-2 block text-sm font-semibold text-teal-600 underline-offset-2 hover:underline dark:text-teal-400 sm:mb-3 sm:text-base"
+                  className="mb-2 block text-sm font-semibold text-indigo-600 underline-offset-2 hover:underline dark:text-indigo-400 sm:mb-3 sm:text-base"
                 >
                   {edu.org}
                 </a>
               ) : (
-                <strong className="mb-2 block text-sm font-semibold text-teal-600 dark:text-teal-400 sm:mb-3 sm:text-base">
+                <strong className="mb-2 block text-sm font-semibold text-indigo-600 dark:text-indigo-400 sm:mb-3 sm:text-base">
                   {edu.org}
                 </strong>
               )}

--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -1,4 +1,4 @@
-import educations from '@/lib/data/education'
+﻿import educations from '@/lib/data/education'
 
 export default function Education() {
   return (
@@ -11,7 +11,7 @@ export default function Education() {
           {educations.map((edu) => (
             <div
               key={edu.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-blue-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-blue-400 sm:p-6 md:p-8"
+              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-teal-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-teal-400 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{edu.course}</span>
@@ -22,12 +22,12 @@ export default function Education() {
                   href={edu.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mb-2 block text-sm font-semibold text-blue-600 underline-offset-2 hover:underline dark:text-blue-400 sm:mb-3 sm:text-base"
+                  className="mb-2 block text-sm font-semibold text-teal-600 underline-offset-2 hover:underline dark:text-teal-400 sm:mb-3 sm:text-base"
                 >
                   {edu.org}
                 </a>
               ) : (
-                <strong className="mb-2 block text-sm font-semibold text-blue-600 dark:text-blue-400 sm:mb-3 sm:text-base">
+                <strong className="mb-2 block text-sm font-semibold text-teal-600 dark:text-teal-400 sm:mb-3 sm:text-base">
                   {edu.org}
                 </strong>
               )}

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -2,7 +2,7 @@
 
 export default function Experience() {
   return (
-    <section className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+    <section className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-zinc-900">
       <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
         <h2 className="mb-8 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-12 md:text-3xl">
           Experience
@@ -11,7 +11,7 @@ export default function Experience() {
           {experiences.map((exp) => (
             <div
               key={exp.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-teal-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-teal-400 sm:p-6 md:p-8"
+              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-indigo-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-indigo-400 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{exp.role}</span>
@@ -22,12 +22,12 @@ export default function Experience() {
                   href={exp.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mb-2 block text-sm font-semibold text-teal-600 underline-offset-2 hover:underline dark:text-teal-400 sm:mb-3 sm:text-base"
+                  className="mb-2 block text-sm font-semibold text-indigo-600 underline-offset-2 hover:underline dark:text-indigo-400 sm:mb-3 sm:text-base"
                 >
                   {exp.org}
                 </a>
               ) : (
-                <strong className="mb-2 block text-sm font-semibold text-teal-600 dark:text-teal-400 sm:mb-3 sm:text-base">
+                <strong className="mb-2 block text-sm font-semibold text-indigo-600 dark:text-indigo-400 sm:mb-3 sm:text-base">
                   {exp.org}
                 </strong>
               )}

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -2,7 +2,7 @@
 
 export default function Experience() {
   return (
-    <section className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-zinc-900">
+    <section className="border-b border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
       <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
         <h2 className="mb-8 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-12 md:text-3xl">
           Experience
@@ -11,7 +11,7 @@ export default function Experience() {
           {experiences.map((exp) => (
             <div
               key={exp.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-indigo-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-indigo-400 sm:p-6 md:p-8"
+              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-indigo-500 dark:border-zinc-700 dark:border-l-gray-200 dark:hover:border-zinc-500 dark:hover:border-l-indigo-400 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{exp.role}</span>

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -1,4 +1,4 @@
-import experiences from '@/lib/data/experience'
+﻿import experiences from '@/lib/data/experience'
 
 export default function Experience() {
   return (
@@ -11,7 +11,7 @@ export default function Experience() {
           {experiences.map((exp) => (
             <div
               key={exp.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-blue-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-blue-400 sm:p-6 md:p-8"
+              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-teal-500 dark:border-gray-700 dark:border-l-gray-200 dark:hover:border-gray-500 dark:hover:border-l-teal-400 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{exp.role}</span>
@@ -22,12 +22,12 @@ export default function Experience() {
                   href={exp.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mb-2 block text-sm font-semibold text-blue-600 underline-offset-2 hover:underline dark:text-blue-400 sm:mb-3 sm:text-base"
+                  className="mb-2 block text-sm font-semibold text-teal-600 underline-offset-2 hover:underline dark:text-teal-400 sm:mb-3 sm:text-base"
                 >
                   {exp.org}
                 </a>
               ) : (
-                <strong className="mb-2 block text-sm font-semibold text-blue-600 dark:text-blue-400 sm:mb-3 sm:text-base">
+                <strong className="mb-2 block text-sm font-semibold text-teal-600 dark:text-teal-400 sm:mb-3 sm:text-base">
                   {exp.org}
                 </strong>
               )}

--- a/components/ImageGallery.tsx
+++ b/components/ImageGallery.tsx
@@ -89,7 +89,7 @@ export default function ImageGallery({ thumbnailUrl, imageUrls = [], title }: Im
   return (
     <>
       {/* ── 갤러리 본체 ── */}
-      <div className="overflow-hidden rounded-2xl bg-gray-100 shadow-md dark:bg-zinc-900">
+      <div className="overflow-hidden rounded-2xl bg-zinc-100 shadow-md dark:bg-zinc-900">
 
         {/* 대표 이미지 */}
         <button
@@ -98,7 +98,7 @@ export default function ImageGallery({ thumbnailUrl, imageUrls = [], title }: Im
           className="group relative block w-full cursor-zoom-in focus:outline-none"
           aria-label="이미지 크게 보기"
         >
-          <div className="relative aspect-video w-full bg-gray-100 dark:bg-zinc-900">
+          <div className="relative aspect-video w-full bg-zinc-100 dark:bg-zinc-900">
             <Image
               src={allImages[selectedIdx]}
               alt={`${title} 이미지 ${selectedIdx + 1}`}

--- a/components/ImageGallery.tsx
+++ b/components/ImageGallery.tsx
@@ -89,7 +89,7 @@ export default function ImageGallery({ thumbnailUrl, imageUrls = [], title }: Im
   return (
     <>
       {/* ── 갤러리 본체 ── */}
-      <div className="overflow-hidden rounded-2xl bg-gray-100 shadow-md dark:bg-gray-900">
+      <div className="overflow-hidden rounded-2xl bg-gray-100 shadow-md dark:bg-zinc-900">
 
         {/* 대표 이미지 */}
         <button
@@ -98,7 +98,7 @@ export default function ImageGallery({ thumbnailUrl, imageUrls = [], title }: Im
           className="group relative block w-full cursor-zoom-in focus:outline-none"
           aria-label="이미지 크게 보기"
         >
-          <div className="relative aspect-video w-full bg-gray-100 dark:bg-gray-900">
+          <div className="relative aspect-video w-full bg-gray-100 dark:bg-zinc-900">
             <Image
               src={allImages[selectedIdx]}
               alt={`${title} 이미지 ${selectedIdx + 1}`}
@@ -138,7 +138,7 @@ export default function ImageGallery({ thumbnailUrl, imageUrls = [], title }: Im
                 onClick={() => { setSelectedIdx(idx); openLightbox(idx) }}
                 className={`relative h-[72px] w-[108px] shrink-0 overflow-hidden rounded-lg transition-all duration-200 focus:outline-none ${
                   idx === selectedIdx
-                    ? 'ring-2 ring-teal-500 ring-offset-1 ring-offset-gray-100 dark:ring-offset-gray-900'
+                    ? 'ring-2 ring-indigo-500 ring-offset-1 ring-offset-gray-100 dark:ring-offset-gray-900'
                     : 'opacity-50 hover:opacity-80'
                 }`}
                 aria-label={`이미지 ${idx + 1} 보기`}

--- a/components/ImageGallery.tsx
+++ b/components/ImageGallery.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import Image from 'next/image'
@@ -138,7 +138,7 @@ export default function ImageGallery({ thumbnailUrl, imageUrls = [], title }: Im
                 onClick={() => { setSelectedIdx(idx); openLightbox(idx) }}
                 className={`relative h-[72px] w-[108px] shrink-0 overflow-hidden rounded-lg transition-all duration-200 focus:outline-none ${
                   idx === selectedIdx
-                    ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-gray-100 dark:ring-offset-gray-900'
+                    ? 'ring-2 ring-teal-500 ring-offset-1 ring-offset-gray-100 dark:ring-offset-gray-900'
                     : 'opacity-50 hover:opacity-80'
                 }`}
                 aria-label={`이미지 ${idx + 1} 보기`}

--- a/components/ImageGalleryUploader.tsx
+++ b/components/ImageGalleryUploader.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useRef, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
@@ -122,18 +122,18 @@ export default function ImageGalleryUploader({ value, onChange }: ImageGalleryUp
           onClick={() => !uploading && inputRef.current?.click()}
           className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed py-6 transition-colors ${
             dragOver
-              ? 'border-blue-400 bg-blue-50 dark:border-blue-500 dark:bg-blue-900/20'
+              ? 'border-teal-400 bg-teal-50 dark:border-teal-500 dark:bg-teal-900/20'
               : 'border-gray-200 bg-gray-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
           }`}
         >
           {uploading ? (
             <>
-              <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600" />
+              <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-300 border-t-teal-600" />
               <p className="mt-2 text-sm text-gray-500">업로드 중...</p>
             </>
           ) : (
             <>
-              <svg className={`h-8 w-8 ${dragOver ? 'text-blue-500' : 'text-gray-300 dark:text-gray-600'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className={`h-8 w-8 ${dragOver ? 'text-teal-500' : 'text-gray-300 dark:text-gray-600'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
               <p className="mt-2 text-sm font-medium text-gray-600 dark:text-gray-400">

--- a/components/ImageGalleryUploader.tsx
+++ b/components/ImageGalleryUploader.tsx
@@ -122,18 +122,18 @@ export default function ImageGalleryUploader({ value, onChange }: ImageGalleryUp
           onClick={() => !uploading && inputRef.current?.click()}
           className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed py-6 transition-colors ${
             dragOver
-              ? 'border-teal-400 bg-teal-50 dark:border-teal-500 dark:bg-teal-900/20'
-              : 'border-gray-200 bg-gray-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
+              ? 'border-indigo-400 bg-indigo-50 dark:border-indigo-500 dark:bg-indigo-900/20'
+              : 'border-gray-200 bg-zinc-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-zinc-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
           }`}
         >
           {uploading ? (
             <>
-              <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-300 border-t-teal-600" />
+              <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
               <p className="mt-2 text-sm text-gray-500">업로드 중...</p>
             </>
           ) : (
             <>
-              <svg className={`h-8 w-8 ${dragOver ? 'text-teal-500' : 'text-gray-300 dark:text-gray-600'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className={`h-8 w-8 ${dragOver ? 'text-indigo-500' : 'text-gray-300 dark:text-gray-600'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
               <p className="mt-2 text-sm font-medium text-gray-600 dark:text-gray-400">

--- a/components/ImageGalleryUploader.tsx
+++ b/components/ImageGalleryUploader.tsx
@@ -90,7 +90,7 @@ export default function ImageGalleryUploader({ value, onChange }: ImageGalleryUp
       {value.length > 0 && (
         <div className="mb-3 grid grid-cols-3 gap-2 sm:grid-cols-4">
           {value.map((url, idx) => (
-            <div key={url} className="group relative aspect-square overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800">
+            <div key={url} className="group relative aspect-square overflow-hidden rounded-xl bg-zinc-100 dark:bg-zinc-800">
               <Image
                 src={url}
                 alt={`갤러리 이미지 ${idx + 1}`}
@@ -123,7 +123,7 @@ export default function ImageGalleryUploader({ value, onChange }: ImageGalleryUp
           className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed py-6 transition-colors ${
             dragOver
               ? 'border-indigo-400 bg-indigo-50 dark:border-indigo-500 dark:bg-indigo-900/20'
-              : 'border-gray-200 bg-zinc-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-zinc-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
+              : 'border-gray-200 bg-zinc-50 hover:border-gray-300 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600 dark:hover:bg-zinc-800'
           }`}
         >
           {uploading ? (

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -65,7 +65,7 @@ export default function LikeButton({ targetType, targetId, initialLikeCount }: L
         className={`flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-150 ${
           liked
             ? 'bg-red-50 text-red-600 ring-1 ring-red-200 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-400 dark:ring-red-800 dark:hover:bg-red-900/30'
-            : 'bg-zinc-100 text-gray-600 ring-1 ring-gray-200 hover:bg-gray-200 dark:bg-zinc-700 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-600'
+            : 'bg-zinc-100 text-gray-600 ring-1 ring-gray-200 hover:bg-gray-200 dark:bg-zinc-700 dark:text-gray-300 dark:ring-zinc-600 dark:hover:bg-zinc-600'
         } ${loading ? 'scale-95 opacity-70' : 'hover:scale-105 active:scale-95'}`}
         aria-label={liked ? '좋아요 취소' : '좋아요'}
       >

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -83,7 +83,7 @@ export default function LikeButton({ targetType, targetId, initialLikeCount }: L
       {!isAuthenticated && (
         <button
           onClick={() => router.push('/login')}
-          className="text-xs text-gray-400 underline-offset-2 hover:text-teal-500 hover:underline dark:text-gray-500 dark:hover:text-teal-400"
+          className="text-xs text-gray-400 underline-offset-2 hover:text-indigo-500 hover:underline dark:text-gray-500 dark:hover:text-indigo-400"
         >
           로그인하고 좋아요 누르기
         </button>

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -65,7 +65,7 @@ export default function LikeButton({ targetType, targetId, initialLikeCount }: L
         className={`flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-150 ${
           liked
             ? 'bg-red-50 text-red-600 ring-1 ring-red-200 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-400 dark:ring-red-800 dark:hover:bg-red-900/30'
-            : 'bg-gray-100 text-gray-600 ring-1 ring-gray-200 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-600'
+            : 'bg-zinc-100 text-gray-600 ring-1 ring-gray-200 hover:bg-gray-200 dark:bg-zinc-700 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-600'
         } ${loading ? 'scale-95 opacity-70' : 'hover:scale-105 active:scale-95'}`}
         aria-label={liked ? '좋아요 취소' : '좋아요'}
       >

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
@@ -83,7 +83,7 @@ export default function LikeButton({ targetType, targetId, initialLikeCount }: L
       {!isAuthenticated && (
         <button
           onClick={() => router.push('/login')}
-          className="text-xs text-gray-400 underline-offset-2 hover:text-blue-500 hover:underline dark:text-gray-500 dark:hover:text-blue-400"
+          className="text-xs text-gray-400 underline-offset-2 hover:text-teal-500 hover:underline dark:text-gray-500 dark:hover:text-teal-400"
         >
           로그인하고 좋아요 누르기
         </button>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
@@ -189,7 +189,7 @@ export default function Navbar() {
                 onClick={() => setMobileMenuOpen(false)}
                 className={`flex items-center gap-3 rounded-xl px-4 py-3.5 text-[0.9rem] font-semibold transition-colors ${
                   isActive(href)
-                    ? 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400'
+                    ? 'bg-teal-50 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400'
                     : 'text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800'
                 }`}
               >

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -97,14 +97,14 @@ export default function Navbar() {
               ))}
             </ul>
 
-            <div className="h-4 w-px bg-gray-200 dark:bg-gray-700" />
+            <div className="h-4 w-px bg-gray-200 dark:bg-zinc-700" />
 
             {mounted && (
               <button
                 onClick={toggleTheme}
                 aria-label="Toggle Dark Mode"
                 title={theme === 'light' ? '다크모드로 전환' : '라이트모드로 전환'}
-                className="flex items-center justify-center rounded-full border border-gray-200 p-[7px] text-gray-400 transition-all duration-200 hover:rotate-[15deg] hover:border-gray-300 hover:text-gray-600 dark:border-gray-700 dark:text-gray-500 dark:hover:border-gray-500 dark:hover:text-gray-300"
+                className="flex items-center justify-center rounded-full border border-gray-200 p-[7px] text-gray-400 transition-all duration-200 hover:rotate-[15deg] hover:border-gray-300 hover:text-gray-600 dark:border-zinc-700 dark:text-gray-500 dark:hover:border-zinc-500 dark:hover:text-gray-300"
               >
                 {theme === 'light' ? <FaMoon size={13} /> : <FaSun size={13} />}
               </button>
@@ -118,7 +118,7 @@ export default function Navbar() {
               <button
                 onClick={toggleTheme}
                 aria-label="Toggle Dark Mode"
-                className="flex items-center justify-center rounded-full border border-gray-200 p-[7px] text-gray-400 dark:border-gray-700 dark:text-gray-500"
+                className="flex items-center justify-center rounded-full border border-gray-200 p-[7px] text-gray-400 dark:border-zinc-700 dark:text-gray-500"
               >
                 {theme === 'light' ? <FaMoon size={13} /> : <FaSun size={13} />}
               </button>
@@ -126,7 +126,7 @@ export default function Navbar() {
             <button
               type="button"
               onClick={() => setMobileMenuOpen(true)}
-              className="flex items-center justify-center rounded-lg p-2 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+              className="flex items-center justify-center rounded-lg p-2 text-gray-500 hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-zinc-800"
               aria-label="메뉴 열기"
             >
               <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -141,7 +141,7 @@ export default function Navbar() {
       <button
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         aria-label="맨 위로"
-        className={`fixed bottom-5 right-4 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all duration-300 hover:border-gray-300 hover:text-gray-600 hover:shadow-md sm:bottom-8 sm:right-8 dark:border-gray-700 dark:bg-zinc-900 dark:text-gray-500 dark:hover:border-gray-500 dark:hover:text-gray-300 ${
+        className={`fixed bottom-5 right-4 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all duration-300 hover:border-gray-300 hover:text-gray-600 hover:shadow-md sm:bottom-8 sm:right-8 dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-500 dark:hover:border-zinc-500 dark:hover:text-gray-300 ${
           showScrollTop ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3 pointer-events-none'
         }`}
       >
@@ -165,14 +165,14 @@ export default function Navbar() {
           mobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
-        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-5 dark:border-gray-800">
+        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-5 dark:border-zinc-800">
           <Link href="/" className="text-lg font-bold text-gray-900 dark:text-white" onClick={() => setMobileMenuOpen(false)}>
             Portfolio
           </Link>
           <button
             type="button"
             onClick={() => setMobileMenuOpen(false)}
-            className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 dark:text-gray-500 dark:hover:bg-gray-800"
+            className="rounded-lg p-2 text-gray-400 hover:bg-zinc-100 dark:text-gray-500 dark:hover:bg-zinc-800"
           >
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -190,7 +190,7 @@ export default function Navbar() {
                 className={`flex items-center gap-3 rounded-xl px-4 py-3.5 text-[0.9rem] font-semibold transition-colors ${
                   isActive(href)
                     ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400'
-                    : 'text-gray-600 hover:bg-zinc-50 dark:text-gray-400 dark:hover:bg-gray-800'
+                    : 'text-gray-600 hover:bg-zinc-50 dark:text-gray-400 dark:hover:bg-zinc-800'
                 }`}
               >
                 {label}
@@ -199,7 +199,7 @@ export default function Navbar() {
           </div>
         </nav>
 
-        <div className="border-t border-gray-100 px-6 py-5 dark:border-gray-800">
+        <div className="border-t border-gray-100 px-6 py-5 dark:border-zinc-800">
           <AuthButton />
         </div>
       </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -141,7 +141,7 @@ export default function Navbar() {
       <button
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         aria-label="맨 위로"
-        className={`fixed bottom-5 right-4 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all duration-300 hover:border-gray-300 hover:text-gray-600 hover:shadow-md sm:bottom-8 sm:right-8 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-500 dark:hover:border-gray-500 dark:hover:text-gray-300 ${
+        className={`fixed bottom-5 right-4 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm transition-all duration-300 hover:border-gray-300 hover:text-gray-600 hover:shadow-md sm:bottom-8 sm:right-8 dark:border-gray-700 dark:bg-zinc-900 dark:text-gray-500 dark:hover:border-gray-500 dark:hover:text-gray-300 ${
           showScrollTop ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3 pointer-events-none'
         }`}
       >
@@ -161,7 +161,7 @@ export default function Navbar() {
 
       {/* Mobile Panel */}
       <div
-        className={`fixed inset-y-0 right-0 z-50 flex w-72 flex-col bg-white shadow-2xl transition-transform duration-300 ease-in-out dark:bg-gray-900 md:hidden ${
+        className={`fixed inset-y-0 right-0 z-50 flex w-72 flex-col bg-white shadow-2xl transition-transform duration-300 ease-in-out dark:bg-zinc-900 md:hidden ${
           mobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
@@ -189,8 +189,8 @@ export default function Navbar() {
                 onClick={() => setMobileMenuOpen(false)}
                 className={`flex items-center gap-3 rounded-xl px-4 py-3.5 text-[0.9rem] font-semibold transition-colors ${
                   isActive(href)
-                    ? 'bg-teal-50 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400'
-                    : 'text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800'
+                    ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400'
+                    : 'text-gray-600 hover:bg-zinc-50 dark:text-gray-400 dark:hover:bg-gray-800'
                 }`}
               >
                 {label}

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+﻿import Image from 'next/image'
 import type { Post } from '@/lib/api/posts'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
@@ -42,7 +42,7 @@ export default function PostCard({ post }: PostCardProps) {
         </div>
 
         {/* 제목 */}
-        <h2 className="mt-1.5 line-clamp-2 text-sm font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400 sm:mt-2 sm:text-base">
+        <h2 className="mt-1.5 line-clamp-2 text-sm font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-teal-600 dark:text-white dark:group-hover:text-teal-400 sm:mt-2 sm:text-base">
           {post.title}
         </h2>
 

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -42,7 +42,7 @@ export default function PostCard({ post }: PostCardProps) {
         </div>
 
         {/* 제목 */}
-        <h2 className="mt-1.5 line-clamp-2 text-sm font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-teal-600 dark:text-white dark:group-hover:text-teal-400 sm:mt-2 sm:text-base">
+        <h2 className="mt-1.5 line-clamp-2 text-sm font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-indigo-600 dark:text-white dark:group-hover:text-indigo-400 sm:mt-2 sm:text-base">
           {post.title}
         </h2>
 

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -17,14 +17,14 @@ const categoryConfig: Record<string, { label: string; className: string }> = {
 const calcReadTime = (content: string) => Math.max(1, Math.ceil(content.length / 500))
 
 export default function PostCard({ post }: PostCardProps) {
-  const category = categoryConfig[post.category] ?? { label: post.category, className: 'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400' }
+  const category = categoryConfig[post.category] ?? { label: post.category, className: 'bg-zinc-100 text-gray-600 ring-gray-500/20 dark:bg-zinc-700 dark:text-gray-400' }
   const readTime = post.readingTime ?? calcReadTime(post.content)
 
   return (
-    <article className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600 sm:flex-row">
+    <article className="group flex flex-row overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-zinc-600">
 
       {/* 텍스트 영역 */}
-      <div className="flex min-w-0 flex-1 flex-col p-4 sm:py-4 sm:pl-5 sm:pr-4">
+      <div className="flex min-w-0 flex-1 flex-col p-3.5 sm:py-4 sm:pl-5 sm:pr-4">
 
         {/* 카테고리 + 태그 */}
         <div className="flex items-center gap-1.5 overflow-hidden">
@@ -32,7 +32,7 @@ export default function PostCard({ post }: PostCardProps) {
             {category.label}
           </span>
           {post.tags.slice(0, 2).map((tag) => (
-            <span key={tag} className="shrink-0 rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400 sm:px-2 sm:text-xs">
+            <span key={tag} className="shrink-0 rounded-md bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-zinc-700 dark:text-gray-400 sm:px-2 sm:text-xs">
               #{tag}
             </span>
           ))}
@@ -52,7 +52,7 @@ export default function PostCard({ post }: PostCardProps) {
         </p>
 
         {/* 메타 */}
-        <div className="mt-auto flex items-center gap-x-3 pt-2 text-[10px] text-gray-400 dark:text-gray-500 sm:gap-x-4 sm:text-xs">
+        <div className="mt-auto flex items-center gap-x-2.5 pt-2 text-[10px] text-gray-400 dark:text-gray-500 sm:gap-x-4 sm:text-xs">
           <span className="flex items-center gap-1">
             <svg className="h-3 w-3 sm:h-3.5 sm:w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -78,14 +78,14 @@ export default function PostCard({ post }: PostCardProps) {
         </div>
       </div>
 
-      {/* 썸네일 — 모바일: 상단 전체 너비(2:1), sm+: 오른쪽 사이드 */}
+      {/* 썸네일 — 모바일/데스크탑 모두 우측 사이드 */}
       {post.thumbnailUrl && (
-        <div className="relative aspect-[2/1] w-full shrink-0 overflow-hidden sm:order-last sm:aspect-auto sm:w-[130px] sm:self-stretch md:w-[160px]">
+        <div className="relative order-last w-[96px] shrink-0 self-stretch overflow-hidden sm:w-[130px] md:w-[160px]">
           <Image
             src={post.thumbnailUrl}
             alt={post.title}
             fill
-            sizes="(max-width: 640px) 100vw, 160px"
+            sizes="(max-width: 640px) 96px, 160px"
             className="object-cover"
           />
         </div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -13,7 +13,7 @@ interface ProjectCardProps {
 
 const statusConfig = {
   completed: { label: '완료', className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
-  'in-progress': { label: '진행중', className: 'bg-teal-50 text-teal-700 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-400 dark:ring-teal-500/30' },
+  'in-progress': { label: '진행중', className: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-400 dark:ring-indigo-500/30' },
   archived: { label: '보관', className: 'bg-gray-100 text-gray-500 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
@@ -80,7 +80,7 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
         </div>
 
         {/* 제목 — 최대 2줄. sm 이상 다열 그리드에서만 고정 높이로 행 정렬 */}
-        <h3 className="mb-2 line-clamp-2 overflow-hidden text-base font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-teal-600 dark:text-white dark:group-hover:text-teal-400 sm:h-[46px]">
+        <h3 className="mb-2 line-clamp-2 overflow-hidden text-base font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-indigo-600 dark:text-white dark:group-hover:text-indigo-400 sm:h-[46px]">
           {project.title}
         </h3>
 
@@ -97,7 +97,7 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
                 key={tech}
                 type="button"
                 onClick={(e) => { e.preventDefault(); e.stopPropagation(); onTechClick(tech) }}
-                className="shrink-0 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-teal-100 hover:text-teal-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-teal-900/40 dark:hover:text-teal-400"
+                className="shrink-0 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-indigo-100 hover:text-indigo-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-indigo-900/40 dark:hover:text-indigo-400"
               >
                 {tech}
               </button>
@@ -108,7 +108,7 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
             )
           )}
           {project.techStack.length > 3 && (
-            <span className="shrink-0 rounded-md bg-teal-50 px-2 py-0.5 text-xs font-semibold text-teal-500 dark:bg-teal-900/30 dark:text-teal-400">
+            <span className="shrink-0 rounded-md bg-indigo-50 px-2 py-0.5 text-xs font-semibold text-indigo-500 dark:bg-indigo-900/30 dark:text-indigo-400">
               +{project.techStack.length - 3}
             </span>
           )}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import Image from 'next/image'
 import type { Project } from '@/lib/api/projects'
@@ -13,7 +13,7 @@ interface ProjectCardProps {
 
 const statusConfig = {
   completed: { label: '완료', className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
-  'in-progress': { label: '진행중', className: 'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-400 dark:ring-blue-500/30' },
+  'in-progress': { label: '진행중', className: 'bg-teal-50 text-teal-700 ring-teal-600/20 dark:bg-teal-900/30 dark:text-teal-400 dark:ring-teal-500/30' },
   archived: { label: '보관', className: 'bg-gray-100 text-gray-500 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
@@ -80,7 +80,7 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
         </div>
 
         {/* 제목 — 최대 2줄. sm 이상 다열 그리드에서만 고정 높이로 행 정렬 */}
-        <h3 className="mb-2 line-clamp-2 overflow-hidden text-base font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400 sm:h-[46px]">
+        <h3 className="mb-2 line-clamp-2 overflow-hidden text-base font-bold leading-[1.4] text-gray-900 transition-colors group-hover:text-teal-600 dark:text-white dark:group-hover:text-teal-400 sm:h-[46px]">
           {project.title}
         </h3>
 
@@ -97,7 +97,7 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
                 key={tech}
                 type="button"
                 onClick={(e) => { e.preventDefault(); e.stopPropagation(); onTechClick(tech) }}
-                className="shrink-0 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-blue-900/40 dark:hover:text-blue-400"
+                className="shrink-0 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-teal-100 hover:text-teal-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-teal-900/40 dark:hover:text-teal-400"
               >
                 {tech}
               </button>
@@ -108,7 +108,7 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
             )
           )}
           {project.techStack.length > 3 && (
-            <span className="shrink-0 rounded-md bg-blue-50 px-2 py-0.5 text-xs font-semibold text-blue-500 dark:bg-blue-900/30 dark:text-blue-400">
+            <span className="shrink-0 rounded-md bg-teal-50 px-2 py-0.5 text-xs font-semibold text-teal-500 dark:bg-teal-900/30 dark:text-teal-400">
               +{project.techStack.length - 3}
             </span>
           )}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -14,7 +14,7 @@ interface ProjectCardProps {
 const statusConfig = {
   completed: { label: '완료', className: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-500/30' },
   'in-progress': { label: '진행중', className: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-900/30 dark:text-indigo-400 dark:ring-indigo-500/30' },
-  archived: { label: '보관', className: 'bg-gray-100 text-gray-500 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-400 dark:ring-gray-500/30' },
+  archived: { label: '보관', className: 'bg-zinc-100 text-gray-500 ring-gray-500/20 dark:bg-zinc-700 dark:text-gray-400 dark:ring-gray-500/30' },
 }
 
 export default function ProjectCard({ project, onTechClick }: ProjectCardProps) {
@@ -23,10 +23,10 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
   const gradient = getTechGradient(project.techStack)
 
   return (
-    <div className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
+    <div className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-zinc-600">
 
       {/* 썸네일 — 모바일에서 2:1 비율로 축소, sm 이상에서 16:9 */}
-      <div className="relative aspect-[2/1] w-full overflow-hidden bg-gray-100 sm:aspect-video dark:bg-gray-700">
+      <div className="relative aspect-[2/1] w-full overflow-hidden bg-zinc-100 sm:aspect-video dark:bg-zinc-700">
         {project.thumbnailUrl ? (
           <Image
             src={project.thumbnailUrl}
@@ -97,12 +97,12 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
                 key={tech}
                 type="button"
                 onClick={(e) => { e.preventDefault(); e.stopPropagation(); onTechClick(tech) }}
-                className="shrink-0 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-indigo-100 hover:text-indigo-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-indigo-900/40 dark:hover:text-indigo-400"
+                className="shrink-0 rounded-md bg-zinc-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-indigo-100 hover:text-indigo-700 dark:bg-zinc-700 dark:text-gray-300 dark:hover:bg-indigo-900/40 dark:hover:text-indigo-400"
               >
                 {tech}
               </button>
             ) : (
-              <span key={tech} className="shrink-0 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              <span key={tech} className="shrink-0 rounded-md bg-zinc-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-zinc-700 dark:text-gray-300">
                 {tech}
               </span>
             )
@@ -115,7 +115,7 @@ export default function ProjectCard({ project, onTechClick }: ProjectCardProps) 
         </div>
 
         {/* 메타 정보 */}
-        <div className="flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-700">
+        <div className="flex items-center justify-between border-t border-gray-100 pt-3 dark:border-zinc-700">
           <div className="flex items-center gap-3.5 text-xs text-gray-400 dark:text-gray-500">
             <span className="flex items-center gap-1">
               <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -11,9 +11,9 @@ export default function Skills() {
           {skills.map(({ icon: Icon, title, items }) => (
             <div
               key={title}
-              className="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:-translate-y-1 hover:border-indigo-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/60 dark:hover:border-indigo-500 sm:p-6"
+              className="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:-translate-y-1 hover:border-indigo-400 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800/60 dark:hover:border-indigo-500 sm:p-6"
             >
-              <div className="mb-3 flex items-center gap-3 border-b border-gray-100 pb-3 dark:border-gray-700 sm:mb-4">
+              <div className="mb-3 flex items-center gap-3 border-b border-gray-100 pb-3 dark:border-zinc-700 sm:mb-4">
                 <Icon className="text-lg text-indigo-600 dark:text-indigo-400 sm:text-xl" />
                 <h3 className="text-sm font-bold text-gray-900 dark:text-white sm:text-base">{title}</h3>
               </div>

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -1,4 +1,4 @@
-import skills from '@/lib/data/skills'
+﻿import skills from '@/lib/data/skills'
 
 export default function Skills() {
   return (
@@ -11,10 +11,10 @@ export default function Skills() {
           {skills.map(({ icon: Icon, title, items }) => (
             <div
               key={title}
-              className="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:-translate-y-1 hover:border-blue-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/60 dark:hover:border-blue-500 sm:p-6"
+              className="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:-translate-y-1 hover:border-teal-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/60 dark:hover:border-teal-500 sm:p-6"
             >
               <div className="mb-3 flex items-center gap-3 border-b border-gray-100 pb-3 dark:border-gray-700 sm:mb-4">
-                <Icon className="text-lg text-blue-600 dark:text-blue-400 sm:text-xl" />
+                <Icon className="text-lg text-teal-600 dark:text-teal-400 sm:text-xl" />
                 <h3 className="text-sm font-bold text-gray-900 dark:text-white sm:text-base">{title}</h3>
               </div>
               <ul className="space-y-1.5 sm:space-y-2">

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -2,7 +2,7 @@
 
 export default function Skills() {
   return (
-    <section className="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50">
+    <section className="border-b border-gray-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900/60">
       <div className="mx-auto max-w-[1000px] px-4 py-12 sm:px-5 md:py-20">
         <h2 className="mb-8 text-center text-2xl font-black tracking-tight text-gray-900 dark:text-white md:mb-12 md:text-3xl">
           Skills & Capabilities
@@ -11,10 +11,10 @@ export default function Skills() {
           {skills.map(({ icon: Icon, title, items }) => (
             <div
               key={title}
-              className="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:-translate-y-1 hover:border-teal-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/60 dark:hover:border-teal-500 sm:p-6"
+              className="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:-translate-y-1 hover:border-indigo-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/60 dark:hover:border-indigo-500 sm:p-6"
             >
               <div className="mb-3 flex items-center gap-3 border-b border-gray-100 pb-3 dark:border-gray-700 sm:mb-4">
-                <Icon className="text-lg text-teal-600 dark:text-teal-400 sm:text-xl" />
+                <Icon className="text-lg text-indigo-600 dark:text-indigo-400 sm:text-xl" />
                 <h3 className="text-sm font-bold text-gray-900 dark:text-white sm:text-base">{title}</h3>
               </div>
               <ul className="space-y-1.5 sm:space-y-2">

--- a/components/TechStackInput.tsx
+++ b/components/TechStackInput.tsx
@@ -150,13 +150,13 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
           {value.map((tech, index) => (
             <span
               key={index}
-              className="flex items-center gap-1 rounded-md bg-teal-100 px-3 py-1.5 text-sm font-medium text-teal-800 dark:bg-teal-900/30 dark:text-teal-300"
+              className="flex items-center gap-1 rounded-md bg-indigo-100 px-3 py-1.5 text-sm font-medium text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300"
             >
               {tech}
               <button
                 type="button"
                 onClick={() => removeTechStack(index)}
-                className="ml-1 rounded hover:bg-teal-200 dark:hover:bg-teal-800"
+                className="ml-1 rounded hover:bg-indigo-200 dark:hover:bg-indigo-800"
               >
                 ×
               </button>
@@ -203,7 +203,7 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
                 key={tech}
                 type="button"
                 onClick={() => addTechStack(tech)}
-                className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-zinc-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
               >
                 + {tech}
               </button>

--- a/components/TechStackInput.tsx
+++ b/components/TechStackInput.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState } from 'react'
 
@@ -150,13 +150,13 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
           {value.map((tech, index) => (
             <span
               key={index}
-              className="flex items-center gap-1 rounded-md bg-blue-100 px-3 py-1.5 text-sm font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+              className="flex items-center gap-1 rounded-md bg-teal-100 px-3 py-1.5 text-sm font-medium text-teal-800 dark:bg-teal-900/30 dark:text-teal-300"
             >
               {tech}
               <button
                 type="button"
                 onClick={() => removeTechStack(index)}
-                className="ml-1 rounded hover:bg-blue-200 dark:hover:bg-blue-800"
+                className="ml-1 rounded hover:bg-teal-200 dark:hover:bg-teal-800"
               >
                 ×
               </button>

--- a/components/TechStackInput.tsx
+++ b/components/TechStackInput.tsx
@@ -146,7 +146,7 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
     <div>
       <div className="relative">
         {/* Selected Tags */}
-        <div className="flex min-h-[46px] flex-wrap gap-2 rounded-lg border border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-zinc-700">
+        <div className="flex min-h-[46px] flex-wrap gap-2 rounded-lg border border-gray-300 bg-white p-2 dark:border-zinc-600 dark:bg-zinc-700">
           {value.map((tech, index) => (
             <span
               key={index}
@@ -178,13 +178,13 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
 
         {/* Autocomplete Suggestions */}
         {suggestions.length > 0 && (
-          <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-zinc-800">
+          <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-zinc-600 dark:bg-zinc-800">
             {suggestions.map((tech, index) => (
               <button
                 key={index}
                 type="button"
                 onClick={() => addTechStack(tech)}
-                className="w-full px-4 py-2.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-gray-700 first:rounded-t-lg last:rounded-b-lg"
+                className="w-full px-4 py-2.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-700 first:rounded-t-lg last:rounded-b-lg"
               >
                 {tech}
               </button>
@@ -203,7 +203,7 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
                 key={tech}
                 type="button"
                 onClick={() => addTechStack(tech)}
-                className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-zinc-50 dark:border-gray-600 dark:bg-zinc-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-700 dark:text-gray-300 dark:hover:bg-zinc-600"
               >
                 + {tech}
               </button>

--- a/components/TechStackInput.tsx
+++ b/components/TechStackInput.tsx
@@ -146,7 +146,7 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
     <div>
       <div className="relative">
         {/* Selected Tags */}
-        <div className="flex min-h-[46px] flex-wrap gap-2 rounded-lg border border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-gray-700">
+        <div className="flex min-h-[46px] flex-wrap gap-2 rounded-lg border border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-zinc-700">
           {value.map((tech, index) => (
             <span
               key={index}
@@ -178,13 +178,13 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
 
         {/* Autocomplete Suggestions */}
         {suggestions.length > 0 && (
-          <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800">
+          <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-zinc-800">
             {suggestions.map((tech, index) => (
               <button
                 key={index}
                 type="button"
                 onClick={() => addTechStack(tech)}
-                className="w-full px-4 py-2.5 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 first:rounded-t-lg last:rounded-b-lg"
+                className="w-full px-4 py-2.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-gray-700 first:rounded-t-lg last:rounded-b-lg"
               >
                 {tech}
               </button>
@@ -203,7 +203,7 @@ export default function TechStackInput({ value, onChange }: TechStackInputProps)
                 key={tech}
                 type="button"
                 onClick={() => addTechStack(tech)}
-                className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-zinc-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-zinc-50 dark:border-gray-600 dark:bg-zinc-700 dark:text-gray-300 dark:hover:bg-gray-600"
               >
                 + {tech}
               </button>

--- a/components/ThumbnailUploader.tsx
+++ b/components/ThumbnailUploader.tsx
@@ -88,8 +88,8 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
 
       {value ? (
         /* 미리보기 */
-        <div className="relative overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
-          <div className="aspect-video w-full overflow-hidden bg-gray-100 dark:bg-gray-800">
+        <div className="relative overflow-hidden rounded-xl border border-gray-200 dark:border-zinc-700">
+          <div className="aspect-video w-full overflow-hidden bg-zinc-100 dark:bg-zinc-800">
             <img
               src={value}
               alt="썸네일 미리보기"
@@ -102,7 +102,7 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
               type="button"
               onClick={() => inputRef.current?.click()}
               disabled={uploading}
-              className="flex items-center gap-1.5 rounded-lg bg-white px-3 py-2 text-xs font-semibold text-gray-900 shadow-md transition-colors hover:bg-gray-100"
+              className="flex items-center gap-1.5 rounded-lg bg-white px-3 py-2 text-xs font-semibold text-gray-900 shadow-md transition-colors hover:bg-zinc-100"
             >
               <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
@@ -136,7 +136,7 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
           className={`flex aspect-video w-full cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed transition-colors ${
             dragOver
               ? 'border-indigo-400 bg-indigo-50 dark:border-indigo-500 dark:bg-indigo-900/20'
-              : 'border-gray-200 bg-zinc-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-zinc-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
+              : 'border-gray-200 bg-zinc-50 hover:border-gray-300 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600 dark:hover:bg-zinc-800'
           }`}
         >
           {uploading ? (
@@ -168,7 +168,7 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder="또는 이미지 URL 직접 입력"
-          className="w-full rounded-xl border border-gray-200 bg-zinc-50 px-4 py-2 text-xs text-gray-600 transition-colors focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-zinc-900 dark:text-gray-400 dark:focus:bg-gray-800"
+          className="w-full rounded-xl border border-gray-200 bg-zinc-50 px-4 py-2 text-xs text-gray-600 transition-colors focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-400 dark:focus:bg-gray-800"
         />
       </div>
 

--- a/components/ThumbnailUploader.tsx
+++ b/components/ThumbnailUploader.tsx
@@ -135,18 +135,18 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
           onClick={() => !uploading && inputRef.current?.click()}
           className={`flex aspect-video w-full cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed transition-colors ${
             dragOver
-              ? 'border-teal-400 bg-teal-50 dark:border-teal-500 dark:bg-teal-900/20'
-              : 'border-gray-200 bg-gray-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
+              ? 'border-indigo-400 bg-indigo-50 dark:border-indigo-500 dark:bg-indigo-900/20'
+              : 'border-gray-200 bg-zinc-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-zinc-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
           }`}
         >
           {uploading ? (
             <>
-              <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-teal-600" />
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
               <p className="mt-3 text-sm text-gray-500">업로드 중...</p>
             </>
           ) : (
             <>
-              <svg className={`h-10 w-10 ${dragOver ? 'text-teal-500' : 'text-gray-300 dark:text-gray-600'}`}
+              <svg className={`h-10 w-10 ${dragOver ? 'text-indigo-500' : 'text-gray-300 dark:text-gray-600'}`}
                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
@@ -168,7 +168,7 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder="또는 이미지 URL 직접 입력"
-          className="w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-2 text-xs text-gray-600 transition-colors focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:focus:bg-gray-800"
+          className="w-full rounded-xl border border-gray-200 bg-zinc-50 px-4 py-2 text-xs text-gray-600 transition-colors focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-zinc-900 dark:text-gray-400 dark:focus:bg-gray-800"
         />
       </div>
 

--- a/components/ThumbnailUploader.tsx
+++ b/components/ThumbnailUploader.tsx
@@ -168,7 +168,7 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder="또는 이미지 URL 직접 입력"
-          className="w-full rounded-xl border border-gray-200 bg-zinc-50 px-4 py-2 text-xs text-gray-600 transition-colors focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-400 dark:focus:bg-gray-800"
+          className="w-full rounded-xl border border-gray-200 bg-zinc-50 px-4 py-2 text-xs text-gray-600 transition-colors focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-400 dark:focus:bg-zinc-800"
         />
       </div>
 

--- a/components/ThumbnailUploader.tsx
+++ b/components/ThumbnailUploader.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useRef } from 'react'
 import { createClient } from '@/lib/supabase/client'
@@ -135,18 +135,18 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
           onClick={() => !uploading && inputRef.current?.click()}
           className={`flex aspect-video w-full cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed transition-colors ${
             dragOver
-              ? 'border-blue-400 bg-blue-50 dark:border-blue-500 dark:bg-blue-900/20'
+              ? 'border-teal-400 bg-teal-50 dark:border-teal-500 dark:bg-teal-900/20'
               : 'border-gray-200 bg-gray-50 hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600 dark:hover:bg-gray-800'
           }`}
         >
           {uploading ? (
             <>
-              <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600" />
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-teal-600" />
               <p className="mt-3 text-sm text-gray-500">업로드 중...</p>
             </>
           ) : (
             <>
-              <svg className={`h-10 w-10 ${dragOver ? 'text-blue-500' : 'text-gray-300 dark:text-gray-600'}`}
+              <svg className={`h-10 w-10 ${dragOver ? 'text-teal-500' : 'text-gray-300 dark:text-gray-600'}`}
                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
@@ -168,7 +168,7 @@ export default function ThumbnailUploader({ value, onChange, className = '' }: T
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder="또는 이미지 URL 직접 입력"
-          className="w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-2 text-xs text-gray-600 transition-colors focus:border-blue-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:focus:bg-gray-800"
+          className="w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-2 text-xs text-gray-600 transition-colors focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:focus:bg-gray-800"
         />
       </div>
 

--- a/components/UpdateTimeline.tsx
+++ b/components/UpdateTimeline.tsx
@@ -132,7 +132,7 @@ export default function UpdateTimeline({ projectId }: Props) {
   const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-indigo-500'
 
   return (
-    <section className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700 sm:p-8">
+    <section className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-zinc-700 sm:p-8">
       {/* 헤더 */}
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -147,7 +147,7 @@ export default function UpdateTimeline({ projectId }: Props) {
           <button
             type="button"
             onClick={() => setShowAddForm(true)}
-            className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-zinc-700"
           >
             <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
@@ -188,7 +188,7 @@ export default function UpdateTimeline({ projectId }: Props) {
             <button
               type="button"
               onClick={() => { setShowAddForm(false); setAddTitle(''); setAddContent(''); setAddExternalUrl('') }}
-              className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-gray-700"
+              className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-zinc-700"
             >
               취소
             </button>
@@ -255,7 +255,7 @@ export default function UpdateTimeline({ projectId }: Props) {
                     <button
                       type="button"
                       onClick={handleEditCancel}
-                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-gray-700"
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-zinc-700"
                     >
                       취소
                     </button>
@@ -290,7 +290,7 @@ export default function UpdateTimeline({ projectId }: Props) {
                           href={item.externalUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex items-center gap-1 rounded-md bg-zinc-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-200 dark:bg-zinc-700 dark:text-gray-400 dark:hover:bg-gray-600"
+                          className="flex items-center gap-1 rounded-md bg-zinc-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-200 dark:bg-zinc-700 dark:text-gray-400 dark:hover:bg-zinc-600"
                         >
                           <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />

--- a/components/UpdateTimeline.tsx
+++ b/components/UpdateTimeline.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect, useMemo } from 'react'
 import ReactMarkdown from 'react-markdown'
@@ -129,7 +129,7 @@ export default function UpdateTimeline({ projectId }: Props) {
     ),
   }), [])
 
-  const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-blue-500'
+  const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-teal-500'
 
   return (
     <section className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:p-8">
@@ -159,8 +159,8 @@ export default function UpdateTimeline({ projectId }: Props) {
 
       {/* 추가 폼 */}
       {isAdmin && showAddForm && (
-        <form onSubmit={handleAdd} className="mb-6 rounded-xl border border-blue-200 bg-blue-50/50 p-4 dark:border-blue-800/50 dark:bg-blue-900/10">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-blue-600 dark:text-blue-400">새 업데이트</p>
+        <form onSubmit={handleAdd} className="mb-6 rounded-xl border border-teal-200 bg-teal-50/50 p-4 dark:border-teal-800/50 dark:bg-teal-900/10">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-teal-600 dark:text-teal-400">새 업데이트</p>
           <div className="space-y-2.5">
             <input
               type="text"
@@ -195,7 +195,7 @@ export default function UpdateTimeline({ projectId }: Props) {
             <button
               type="submit"
               disabled={addSubmitting || !addTitle.trim() || !addContent.trim()}
-              className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {addSubmitting ? (
                 <>
@@ -211,7 +211,7 @@ export default function UpdateTimeline({ projectId }: Props) {
       {/* 타임라인 목록 */}
       {loading ? (
         <div className="flex justify-center py-8">
-          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600" />
+          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-teal-600" />
         </div>
       ) : updates.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700">
@@ -225,11 +225,11 @@ export default function UpdateTimeline({ projectId }: Props) {
           {updates.map((item) => (
             <li key={item.id} className="mb-5 ml-4 last:mb-0 sm:mb-8">
               {/* 타임라인 점 */}
-              <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-white bg-blue-500 dark:border-gray-800 dark:bg-blue-400" />
+              <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-white bg-teal-500 dark:border-gray-800 dark:bg-teal-400" />
 
               {editingId === item.id ? (
                 /* 수정 폼 */
-                <div className="rounded-xl border border-blue-200 bg-blue-50/50 p-4 dark:border-blue-800/50 dark:bg-blue-900/10">
+                <div className="rounded-xl border border-teal-200 bg-teal-50/50 p-4 dark:border-teal-800/50 dark:bg-teal-900/10">
                   <div className="space-y-2.5">
                     <input
                       type="text"
@@ -268,7 +268,7 @@ export default function UpdateTimeline({ projectId }: Props) {
                         !editContent.trim() ||
                         (editTitle.trim() === item.title && editContent.trim() === item.content && editExternalUrl.trim() === (item.externalUrl ?? ''))
                       }
-                      className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {editSubmitting ? (
                         <>
@@ -308,7 +308,7 @@ export default function UpdateTimeline({ projectId }: Props) {
                           <button
                             type="button"
                             onClick={() => handleEditStart(item)}
-                            className="rounded p-0.5 text-gray-300 transition-colors hover:text-blue-500 dark:text-gray-600 dark:hover:text-blue-400"
+                            className="rounded p-0.5 text-gray-300 transition-colors hover:text-teal-500 dark:text-gray-600 dark:hover:text-teal-400"
                             aria-label="수정"
                           >
                             <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/components/UpdateTimeline.tsx
+++ b/components/UpdateTimeline.tsx
@@ -129,10 +129,10 @@ export default function UpdateTimeline({ projectId }: Props) {
     ),
   }), [])
 
-  const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-zinc-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-indigo-500'
+  const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-indigo-500'
 
   return (
-    <section className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:p-8">
+    <section className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:ring-gray-700 sm:p-8">
       {/* 헤더 */}
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -147,7 +147,7 @@ export default function UpdateTimeline({ projectId }: Props) {
           <button
             type="button"
             onClick={() => setShowAddForm(true)}
-            className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
@@ -188,7 +188,7 @@ export default function UpdateTimeline({ projectId }: Props) {
             <button
               type="button"
               onClick={() => { setShowAddForm(false); setAddTitle(''); setAddContent(''); setAddExternalUrl('') }}
-              className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+              className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-gray-700"
             >
               취소
             </button>
@@ -214,18 +214,18 @@ export default function UpdateTimeline({ projectId }: Props) {
           <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-indigo-600" />
         </div>
       ) : updates.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700">
+        <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-zinc-700">
           <svg className="mx-auto mb-3 h-10 w-10 text-gray-300 dark:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <p className="text-sm text-gray-400 dark:text-gray-500">아직 업데이트 내역이 없습니다.</p>
         </div>
       ) : (
-        <ol className="relative border-l border-gray-200 dark:border-gray-700">
+        <ol className="relative border-l border-gray-200 dark:border-zinc-700">
           {updates.map((item) => (
             <li key={item.id} className="mb-5 ml-4 last:mb-0 sm:mb-8">
               {/* 타임라인 점 */}
-              <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-white bg-indigo-500 dark:border-gray-800 dark:bg-indigo-400" />
+              <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-white bg-indigo-500 dark:border-zinc-800 dark:bg-indigo-400" />
 
               {editingId === item.id ? (
                 /* 수정 폼 */
@@ -255,7 +255,7 @@ export default function UpdateTimeline({ projectId }: Props) {
                     <button
                       type="button"
                       onClick={handleEditCancel}
-                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-zinc-100 dark:text-gray-400 dark:hover:bg-gray-700"
                     >
                       취소
                     </button>
@@ -290,7 +290,7 @@ export default function UpdateTimeline({ projectId }: Props) {
                           href={item.externalUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex items-center gap-1 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
+                          className="flex items-center gap-1 rounded-md bg-zinc-100 px-2 py-0.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-200 dark:bg-zinc-700 dark:text-gray-400 dark:hover:bg-gray-600"
                         >
                           <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />

--- a/components/UpdateTimeline.tsx
+++ b/components/UpdateTimeline.tsx
@@ -129,7 +129,7 @@ export default function UpdateTimeline({ projectId }: Props) {
     ),
   }), [])
 
-  const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-teal-500'
+  const inputClass = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-700 dark:bg-zinc-900 dark:text-gray-200 dark:placeholder-gray-500 dark:focus:border-indigo-500'
 
   return (
     <section className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:ring-gray-700 sm:p-8">
@@ -147,7 +147,7 @@ export default function UpdateTimeline({ projectId }: Props) {
           <button
             type="button"
             onClick={() => setShowAddForm(true)}
-            className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
@@ -159,8 +159,8 @@ export default function UpdateTimeline({ projectId }: Props) {
 
       {/* 추가 폼 */}
       {isAdmin && showAddForm && (
-        <form onSubmit={handleAdd} className="mb-6 rounded-xl border border-teal-200 bg-teal-50/50 p-4 dark:border-teal-800/50 dark:bg-teal-900/10">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-teal-600 dark:text-teal-400">새 업데이트</p>
+        <form onSubmit={handleAdd} className="mb-6 rounded-xl border border-indigo-200 bg-indigo-50/50 p-4 dark:border-indigo-800/50 dark:bg-indigo-900/10">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-indigo-600 dark:text-indigo-400">새 업데이트</p>
           <div className="space-y-2.5">
             <input
               type="text"
@@ -195,7 +195,7 @@ export default function UpdateTimeline({ projectId }: Props) {
             <button
               type="submit"
               disabled={addSubmitting || !addTitle.trim() || !addContent.trim()}
-              className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-lg bg-indigo-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {addSubmitting ? (
                 <>
@@ -211,7 +211,7 @@ export default function UpdateTimeline({ projectId }: Props) {
       {/* 타임라인 목록 */}
       {loading ? (
         <div className="flex justify-center py-8">
-          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-teal-600" />
+          <div className="h-7 w-7 animate-spin rounded-full border-4 border-gray-200 border-t-indigo-600" />
         </div>
       ) : updates.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center dark:border-gray-700">
@@ -225,11 +225,11 @@ export default function UpdateTimeline({ projectId }: Props) {
           {updates.map((item) => (
             <li key={item.id} className="mb-5 ml-4 last:mb-0 sm:mb-8">
               {/* 타임라인 점 */}
-              <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-white bg-teal-500 dark:border-gray-800 dark:bg-teal-400" />
+              <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-white bg-indigo-500 dark:border-gray-800 dark:bg-indigo-400" />
 
               {editingId === item.id ? (
                 /* 수정 폼 */
-                <div className="rounded-xl border border-teal-200 bg-teal-50/50 p-4 dark:border-teal-800/50 dark:bg-teal-900/10">
+                <div className="rounded-xl border border-indigo-200 bg-indigo-50/50 p-4 dark:border-indigo-800/50 dark:bg-indigo-900/10">
                   <div className="space-y-2.5">
                     <input
                       type="text"
@@ -268,7 +268,7 @@ export default function UpdateTimeline({ projectId }: Props) {
                         !editContent.trim() ||
                         (editTitle.trim() === item.title && editContent.trim() === item.content && editExternalUrl.trim() === (item.externalUrl ?? ''))
                       }
-                      className="flex items-center gap-1.5 rounded-lg bg-teal-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="flex items-center gap-1.5 rounded-lg bg-indigo-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {editSubmitting ? (
                         <>
@@ -308,7 +308,7 @@ export default function UpdateTimeline({ projectId }: Props) {
                           <button
                             type="button"
                             onClick={() => handleEditStart(item)}
-                            className="rounded p-0.5 text-gray-300 transition-colors hover:text-teal-500 dark:text-gray-600 dark:hover:text-teal-400"
+                            className="rounded p-0.5 text-gray-300 transition-colors hover:text-indigo-500 dark:text-gray-600 dark:hover:text-indigo-400"
                             aria-label="수정"
                           >
                             <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-interface ConfirmDialogProps {
+﻿interface ConfirmDialogProps {
   open: boolean
   title: string
   description: string
@@ -24,7 +24,7 @@ export default function ConfirmDialog({
   const confirmBtnClass = {
     danger: 'bg-red-600 hover:bg-red-700 text-white',
     warning: 'bg-amber-500 hover:bg-amber-600 text-white',
-    default: 'bg-blue-600 hover:bg-blue-700 text-white',
+    default: 'bg-teal-600 hover:bg-teal-700 text-white',
   }[variant]
 
   const iconMap = {

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -51,7 +51,7 @@ export default function ConfirmDialog({
       onClick={onCancel}
     >
       <div
-        className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl dark:bg-gray-800 sm:p-6"
+        className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl dark:bg-zinc-800 sm:p-6"
         onClick={(e) => e.stopPropagation()}
       >
         {iconMap && <div className="mb-4">{iconMap}</div>}
@@ -60,7 +60,7 @@ export default function ConfirmDialog({
         <div className="flex gap-2.5 sm:gap-3">
           <button
             onClick={onCancel}
-            className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm"
+            className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm"
           >
             {cancelLabel}
           </button>

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -60,7 +60,7 @@ export default function ConfirmDialog({
         <div className="flex gap-2.5 sm:gap-3">
           <button
             onClick={onCancel}
-            className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm"
+            className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-gray-300 dark:hover:bg-zinc-700 sm:py-2.5 sm:text-sm"
           >
             {cancelLabel}
           </button>

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -24,7 +24,7 @@ export default function ConfirmDialog({
   const confirmBtnClass = {
     danger: 'bg-red-600 hover:bg-red-700 text-white',
     warning: 'bg-amber-500 hover:bg-amber-600 text-white',
-    default: 'bg-teal-600 hover:bg-teal-700 text-white',
+    default: 'bg-indigo-600 hover:bg-indigo-700 text-white',
   }[variant]
 
   const iconMap = {
@@ -60,7 +60,7 @@ export default function ConfirmDialog({
         <div className="flex gap-2.5 sm:gap-3">
           <button
             onClick={onCancel}
-            className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm"
+            className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-zinc-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 sm:py-2.5 sm:text-sm"
           >
             {cancelLabel}
           </button>

--- a/components/ui/PostCardSkeleton.tsx
+++ b/components/ui/PostCardSkeleton.tsx
@@ -1,33 +1,33 @@
-export default function PostCardSkeleton() {
+﻿export default function PostCardSkeleton() {
   return (
-    <div className="flex overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+    <div className="flex overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-zinc-700 dark:bg-zinc-800">
       {/* 텍스트 영역 */}
       <div className="flex min-w-0 flex-1 flex-col py-3.5 pl-4 pr-3 sm:py-4 sm:pl-5 sm:pr-4">
         {/* 카테고리 + 태그 */}
         <div className="flex items-center gap-1.5">
-          <div className="h-5 w-16 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
-          <div className="h-5 w-12 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
+          <div className="h-5 w-16 animate-pulse rounded-full bg-gray-200 dark:bg-zinc-700" />
+          <div className="h-5 w-12 animate-pulse rounded-md bg-gray-200 dark:bg-zinc-700" />
         </div>
         {/* 제목 */}
         <div className="mt-2 space-y-1.5">
-          <div className="h-4 w-full animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
-          <div className="h-4 w-3/4 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-4 w-full animate-pulse rounded bg-gray-200 dark:bg-zinc-700" />
+          <div className="h-4 w-3/4 animate-pulse rounded bg-gray-200 dark:bg-zinc-700" />
         </div>
         {/* 요약 */}
         <div className="mt-2 space-y-1.5">
-          <div className="h-3.5 w-full animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
-          <div className="h-3.5 w-5/6 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
+          <div className="h-3.5 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
+          <div className="h-3.5 w-5/6 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
         </div>
         {/* 메타 */}
         <div className="mt-auto flex items-center gap-3 pt-2">
-          <div className="h-3 w-8 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
-          <div className="h-3 w-8 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
-          <div className="h-3 w-8 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
-          <div className="ml-auto h-3 w-14 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
+          <div className="h-3 w-8 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
+          <div className="h-3 w-8 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
+          <div className="h-3 w-8 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
+          <div className="ml-auto h-3 w-14 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
         </div>
       </div>
       {/* 썸네일 자리 */}
-      <div className="w-[110px] shrink-0 animate-pulse bg-gray-200 dark:bg-gray-700 sm:w-[150px] md:w-[170px]" />
+      <div className="w-[110px] shrink-0 animate-pulse bg-gray-200 dark:bg-zinc-700 sm:w-[150px] md:w-[170px]" />
     </div>
   )
 }

--- a/components/ui/ProjectCardSkeleton.tsx
+++ b/components/ui/ProjectCardSkeleton.tsx
@@ -1,37 +1,37 @@
-export default function ProjectCardSkeleton() {
+﻿export default function ProjectCardSkeleton() {
   return (
-    <div className="flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+    <div className="flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
       {/* 썸네일 */}
-      <div className="aspect-video w-full animate-pulse bg-gray-200 dark:bg-gray-700" />
+      <div className="aspect-video w-full animate-pulse bg-gray-200 dark:bg-zinc-700" />
 
       {/* 콘텐츠 */}
       <div className="flex flex-col p-5">
         {/* 상태 배지 */}
-        <div className="mb-2.5 h-[22px] w-12 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+        <div className="mb-2.5 h-[22px] w-12 animate-pulse rounded-full bg-gray-200 dark:bg-zinc-700" />
         {/* 제목 */}
         <div className="mb-2 space-y-1.5">
-          <div className="h-[22px] w-full animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
-          <div className="h-[22px] w-2/3 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-[22px] w-full animate-pulse rounded bg-gray-200 dark:bg-zinc-700" />
+          <div className="h-[22px] w-2/3 animate-pulse rounded bg-gray-200 dark:bg-zinc-700" />
         </div>
         {/* 요약 */}
         <div className="mb-3.5 space-y-1.5">
-          <div className="h-4 w-full animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
-          <div className="h-4 w-full animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
-          <div className="h-4 w-4/5 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
+          <div className="h-4 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
+          <div className="h-4 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
+          <div className="h-4 w-4/5 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
         </div>
         {/* 기술 스택 */}
         <div className="mb-3.5 flex items-center gap-1.5">
-          <div className="h-[26px] w-16 animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/60" />
-          <div className="h-[26px] w-16 animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/60" />
-          <div className="h-[26px] w-16 animate-pulse rounded-md bg-gray-100 dark:bg-gray-700/60" />
+          <div className="h-[26px] w-16 animate-pulse rounded-md bg-zinc-100 dark:bg-zinc-700/60" />
+          <div className="h-[26px] w-16 animate-pulse rounded-md bg-zinc-100 dark:bg-zinc-700/60" />
+          <div className="h-[26px] w-16 animate-pulse rounded-md bg-zinc-100 dark:bg-zinc-700/60" />
         </div>
         {/* 메타 */}
-        <div className="flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-700">
+        <div className="flex items-center justify-between border-t border-gray-100 pt-3 dark:border-zinc-700">
           <div className="flex items-center gap-3">
-            <div className="h-3 w-8 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
-            <div className="h-3 w-8 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
+            <div className="h-3 w-8 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
+            <div className="h-3 w-8 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
           </div>
-          <div className="h-3 w-14 animate-pulse rounded bg-gray-100 dark:bg-gray-700/60" />
+          <div className="h-3 w-14 animate-pulse rounded bg-zinc-100 dark:bg-zinc-700/60" />
         </div>
       </div>
     </div>

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -1,4 +1,4 @@
-interface SpinnerProps {
+﻿interface SpinnerProps {
   size?: 'sm' | 'md'
 }
 
@@ -8,7 +8,7 @@ export default function Spinner({ size = 'md' }: SpinnerProps) {
     : 'h-10 w-10 border-4'
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-      <div className={`${cls} animate-spin rounded-full border-gray-200 border-t-blue-600`} />
+      <div className={`${cls} animate-spin rounded-full border-gray-200 border-t-teal-600`} />
     </div>
   )
 }

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -7,8 +7,8 @@ export default function Spinner({ size = 'md' }: SpinnerProps) {
     ? 'h-8 w-8 border-[3px]'
     : 'h-10 w-10 border-4'
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
-      <div className={`${cls} animate-spin rounded-full border-gray-200 border-t-teal-600`} />
+    <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
+      <div className={`${cls} animate-spin rounded-full border-gray-200 border-t-indigo-600`} />
     </div>
   )
 }

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useEffect, useState } from 'react'
 import { ToastContext, useToastState, type Toast } from '@/hooks/useToast'
@@ -39,7 +39,7 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: () => void }) 
 
   return (
     <div
-      className={`relative flex w-full max-w-sm items-start gap-3 overflow-hidden rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-lg transition-all duration-300 dark:border-gray-700 dark:bg-gray-800 ${
+      className={`relative flex w-full max-w-sm items-start gap-3 overflow-hidden rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-lg transition-all duration-300 dark:border-zinc-700 dark:bg-zinc-800 ${
         visible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
       }`}
     >

--- a/lib/styles/form.ts
+++ b/lib/styles/form.ts
@@ -6,4 +6,4 @@ export const inputClass =
   'w-full rounded-lg border border-gray-200 bg-zinc-50 px-4 py-2.5 text-sm text-gray-900 transition-colors ' +
   'focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 ' +
   'dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:placeholder-gray-500 ' +
-  'dark:focus:border-indigo-500 dark:focus:bg-gray-800/80'
+  'dark:focus:border-indigo-500 dark:focus:bg-zinc-800/80'

--- a/lib/styles/form.ts
+++ b/lib/styles/form.ts
@@ -5,5 +5,5 @@
 export const inputClass =
   'w-full rounded-lg border border-gray-200 bg-zinc-50 px-4 py-2.5 text-sm text-gray-900 transition-colors ' +
   'focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 ' +
-  'dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 ' +
+  'dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:placeholder-gray-500 ' +
   'dark:focus:border-indigo-500 dark:focus:bg-gray-800/80'

--- a/lib/styles/form.ts
+++ b/lib/styles/form.ts
@@ -1,9 +1,9 @@
-/**
+﻿/**
  * 폼 관련 공통 Tailwind 클래스
  */
 
 export const inputClass =
   'w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-gray-900 transition-colors ' +
-  'focus:border-blue-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 ' +
+  'focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20 ' +
   'dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 ' +
-  'dark:focus:border-blue-500 dark:focus:bg-gray-800/80'
+  'dark:focus:border-teal-500 dark:focus:bg-gray-800/80'

--- a/lib/styles/form.ts
+++ b/lib/styles/form.ts
@@ -3,7 +3,7 @@
  */
 
 export const inputClass =
-  'w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-gray-900 transition-colors ' +
-  'focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20 ' +
+  'w-full rounded-lg border border-gray-200 bg-zinc-50 px-4 py-2.5 text-sm text-gray-900 transition-colors ' +
+  'focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 ' +
   'dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500 ' +
-  'dark:focus:border-teal-500 dark:focus:bg-gray-800/80'
+  'dark:focus:border-indigo-500 dark:focus:bg-gray-800/80'

--- a/lib/utils/devicon.ts
+++ b/lib/utils/devicon.ts
@@ -104,13 +104,13 @@ export function getDeviconUrls(techStack: string[], max = 3): string[] {
  */
 export function getTechGradient(techStack: string[]): string {
   const gradients = [
-    'from-teal-500 to-violet-600',
-    'from-emerald-500 to-teal-600',
+    'from-indigo-500 to-violet-600',
+    'from-emerald-500 to-indigo-600',
     'from-orange-500 to-amber-600',
     'from-pink-500 to-rose-600',
-    'from-cyan-500 to-teal-600',
+    'from-cyan-500 to-indigo-600',
     'from-violet-500 to-purple-600',
-    'from-teal-500 to-green-600',
+    'from-indigo-500 to-green-600',
     'from-red-500 to-orange-600',
   ]
   const seed = techStack.join('').split('').reduce((acc, c) => acc + c.charCodeAt(0), 0)

--- a/lib/utils/devicon.ts
+++ b/lib/utils/devicon.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * 기술 스택 이름 → devicons CDN 아이콘 URL 매핑
  * https://cdn.jsdelivr.net/gh/devicons/devicon/icons/{name}/{name}-original.svg
  */
@@ -104,11 +104,11 @@ export function getDeviconUrls(techStack: string[], max = 3): string[] {
  */
 export function getTechGradient(techStack: string[]): string {
   const gradients = [
-    'from-blue-500 to-violet-600',
+    'from-teal-500 to-violet-600',
     'from-emerald-500 to-teal-600',
     'from-orange-500 to-amber-600',
     'from-pink-500 to-rose-600',
-    'from-cyan-500 to-blue-600',
+    'from-cyan-500 to-teal-600',
     'from-violet-500 to-purple-600',
     'from-teal-500 to-green-600',
     'from-red-500 to-orange-600',


### PR DESCRIPTION
## 관련 이슈
closes #139
Jira: FRONT-54

## 변경 유형
- [x] Enhancement (UI/디자인 개선)

## 변경 내용

### 히어로 섹션 모바일 레이아웃
- `flex-col-reverse` 적용 → 사진이 모바일에서 텍스트 위에 배치
- 프로필 이미지: 사각형+오프셋섀도우 → **원형(rounded-full)** + 부드러운 그림자
- 텍스트 정렬: `text-center` 제거 → **좌정렬**로 자연스러운 레이아웃
- 역할 뱃지 추가: `웹 · 시스템 개발자` teal chip (h1 상단)
- CTA 버튼: 모바일에서 좌정렬

### 컬러 시스템
- 전체 `blue-*` → `teal-*` 일괄 교체 (37개 파일)
- globals.css 마크다운 링크/인용구 hex 색상 teal 계열로 변경
- 페이지 배경: `bg-gray-50` → `bg-stone-50` / CSS 변수 `#fafaf9` (따뜻한 중립)

## 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] lint 에러 없음 (0 errors)
- [x] 불필요한 console.log 없음