### PR TITLE
FRONT-61: refactor: Experience/Education 카드 좌측 stripe 제거 + zinc 정합

### DIFF
--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -11,7 +11,7 @@ export default function Education() {
           {educations.map((edu) => (
             <div
               key={edu.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-indigo-500 dark:border-zinc-700 dark:border-l-gray-200 dark:hover:border-zinc-500 dark:hover:border-l-indigo-400 sm:p-6 md:p-8"
+              className="rounded-lg border border-zinc-200 bg-transparent p-4 transition-colors duration-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-500 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{edu.course}</span>

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -11,7 +11,7 @@ export default function Experience() {
           {experiences.map((exp) => (
             <div
               key={exp.id}
-              className="rounded-lg border border-gray-200 border-l-[5px] border-l-gray-800 bg-transparent p-4 transition-colors duration-200 hover:border-gray-400 hover:border-l-indigo-500 dark:border-zinc-700 dark:border-l-gray-200 dark:hover:border-zinc-500 dark:hover:border-l-indigo-400 sm:p-6 md:p-8"
+              className="rounded-lg border border-zinc-200 bg-transparent p-4 transition-colors duration-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-500 sm:p-6 md:p-8"
             >
               <div className="mb-1 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                 <span className="text-base font-extrabold text-gray-900 dark:text-white sm:text-xl">{exp.role}</span>


### PR DESCRIPTION
## 관련 이슈
closes #154
Jira: FRONT-61

## 변경 유형
- [x] Refactor

## 변경 내용
- 좌측 두꺼운 accent stripe 제거 (AI 생성 디자인 인상 정리)
  - `border-l-[5px] border-l-gray-800` 및 다크 변형 삭제
  - `hover:border-l-indigo-500` 및 다크 변형 삭제
- 디자인 시스템 정합 (FRONT-54)
  - `border-gray-200` → `border-zinc-200`
  - `hover:border-gray-400` → `hover:border-zinc-300`
- 대상: `components/Experience.tsx`, `components/Education.tsx` (동일한 카드 className)

indigo 액센트는 카드 안쪽 org/기관명 링크에만 유지 → 테마 정체성 보존.

## 체크리스트
- [x] 로컬에서 정상 동작 확인 (className-only 변경, 로직 무변경)
- [x] 콘솔 에러 없음
- [x] 불필요한 console.log 제거
- [x] npm run lint 통과 (Education/Experience 신규 경고 없음)